### PR TITLE
A2.2: required switch positions for a leg

### DIFF
--- a/Controller/src/python/planner.py
+++ b/Controller/src/python/planner.py
@@ -8,12 +8,48 @@ from PySide6.QtCore import QObject, Slot
 
 
 @dataclass(frozen=True)
+class RequiredSwitch:
+    """Switch rail position required for a planned leg (rail_id → path_id A|B)."""
+
+    rail_id: int
+    path_id: str
+
+
+@dataclass(frozen=True)
 class LegResult:
     """Shortest-path leg between two graph nodes (QObject-free)."""
 
     nodes: list[str]
     segments: list[str]
     length: float
+    required_switches: tuple[RequiredSwitch, ...] = ()
+
+
+def collect_required_switches(rails, graph, nodes: list[str]) -> tuple[RequiredSwitch, ...] | None:
+    """Derive required switch positions from path segment_data (not live switch state).
+
+    Returns None if the same switch rail appears with conflicting path_ids.
+    Non-switch rails are ignored. Order is first appearance along the path.
+    """
+    if graph is None or not nodes:
+        return ()
+
+    ordered: dict[int, str] = {}
+    for i in range(len(nodes) - 1):
+        a, b = nodes[i], nodes[i + 1]
+        edge_data = graph.get_edge_data(a, b) or {}
+        for rail_data in edge_data.get("segment_data", []):
+            rail_id = int(rail_data["rail_id"])
+            path_id = rail_data["path_id"]
+            rail = rails.findRailData(rail_id)
+            if rail is None or not rail.is_switch():
+                continue
+            if rail_id in ordered and ordered[rail_id] != path_id:
+                return None
+            if rail_id not in ordered:
+                ordered[rail_id] = path_id
+
+    return tuple(RequiredSwitch(rail_id=rid, path_id=pid) for rid, pid in ordered.items())
 
 
 class Planner(QObject):
@@ -28,17 +64,19 @@ class Planner(QObject):
     def compute_leg(self, from_node: str, to_node: str) -> LegResult | None:
         """Shortest path between two marker (or graph) nodes.
 
-        Uses undirected edge weights. Switch position is not applied yet — the path
-        may include either switch branch. A2.2 will add required_switches.
+        Uses undirected edge weights. Switch position is not applied during search —
+        either branch may appear. required_switches lists SwitchLeft/SwitchRight
+        path_ids from the chosen path's segment_data (not live rail.switch_position).
 
         Same-node (when the node exists): trivial leg with that node, empty
-        segments, and length 0. Unknown nodes, missing graph, or no path: None.
+        segments, length 0, and no required switches. Unknown nodes, missing
+        graph, no path, or conflicting switch path_ids on one leg: None.
         """
         graph = self._network.graph()
         if graph is None or from_node not in graph or to_node not in graph:
             return None
         if from_node == to_node:
-            return LegResult(nodes=[from_node], segments=[], length=0.0)
+            return LegResult(nodes=[from_node], segments=[], length=0.0, required_switches=())
         try:
             nodes = nx.shortest_path(graph, from_node, to_node, weight="weight")
             length = nx.shortest_path_length(graph, from_node, to_node, weight="weight")
@@ -48,7 +86,15 @@ class Planner(QObject):
             f"{a}:{b}"
             for a, b in (sorted((nodes[i], nodes[i + 1])) for i in range(len(nodes) - 1))
         ]
-        return LegResult(nodes=nodes, segments=segments, length=float(length))
+        required = collect_required_switches(self._rails, graph, nodes)
+        if required is None:
+            return None
+        return LegResult(
+            nodes=nodes,
+            segments=segments,
+            length=float(length),
+            required_switches=required,
+        )
 
     @Slot(str)
     def reserve(self, segment_id):

--- a/Controller/tests/test_planner.py
+++ b/Controller/tests/test_planner.py
@@ -1,13 +1,18 @@
 from pathlib import Path
 from unittest.mock import MagicMock
 
+import networkx as nx
 import pytest
+from PySide6.QtGui import QColor
 from PySide6.QtWidgets import QApplication
 
 import python.models.project_storage as project
 import python.network_manager as net
-from python.items.rail import Rail
-from python.planner import Planner
+from python.connectorregister import ConnectorRegister
+from python.items.marker import MarkerState
+from python.items.rail import Rail, RailType
+from python.models.rails import Rails
+from python.planner import Planner, RequiredSwitch, collect_required_switches
 
 TEST_TRACK = "tests/tracks/rails.json"
 
@@ -31,6 +36,46 @@ def _planner_from_track(path: str):
     return Planner(mock_rails, network), network
 
 
+def _make_switch_y_layout():
+    """Straight approach into SwitchLeft with two straight exits (A and B)."""
+    rails = Rails(ConnectorRegister())
+    rails._items = [
+        Rail(type=RailType.Straight, id=1, parent=rails),
+        Rail(type=RailType.SwitchLeft, id=2, parent=rails),
+        Rail(type=RailType.Straight, id=3, parent=rails),
+        Rail(type=RailType.Straight, id=4, parent=rails),
+    ]
+    approach, switch, exit_a, exit_b = rails._items
+    approach.connectTo(switch.id, 1)
+    switch.connectTo(approach.id, 0)
+    switch.connectTo(exit_a.id, 2)  # end_straight / path A
+    exit_a.connectTo(switch.id, 0)
+    switch.connectTo(exit_b.id, 1)  # end_curved / path B
+    exit_b.connectTo(switch.id, 0)
+    return rails, switch
+
+
+def _force_take(rail, distance, color, path_id=None):
+    marker = next(
+        m for m in rail.markers._items
+        if m.distance == distance and (path_id is None or m.path_id in (None, "", path_id))
+    )
+    marker.set_color(QColor(color))
+    marker.set_state(MarkerState.Taken)
+    return marker
+
+
+def _planner_from_switch_y_with_markers():
+    rails, switch = _make_switch_y_layout()
+    approach, _switch_rail, exit_a, exit_b = rails._items
+    _force_take(approach, 8, "#ff0000")
+    _force_take(exit_a, 8, "#00ff00")
+    _force_take(exit_b, 8, "#0000ff")
+    network = net.NetworkManager(rails)
+    network.generate()
+    return Planner(rails, network), network, switch
+
+
 def test_compute_leg_shortest_path_between_markers():
     planner, network = _planner_from_track(TEST_TRACK)
     from_node = network.find_node_by_color("#ffff00")
@@ -48,6 +93,7 @@ def test_compute_leg_shortest_path_between_markers():
     assert leg.nodes == ["6A8", "10A0", "13A0"]
     assert leg.segments == ["10A0:6A8", "10A0:13A0"]
     assert leg.length == 104
+    assert leg.required_switches == ()
 
 
 def test_compute_leg_same_node_is_trivial():
@@ -60,6 +106,7 @@ def test_compute_leg_same_node_is_trivial():
     assert leg.nodes == [node]
     assert leg.segments == []
     assert leg.length == 0.0
+    assert leg.required_switches == ()
 
 
 def test_compute_leg_unknown_node_returns_none():
@@ -78,3 +125,44 @@ def test_compute_leg_no_graph_returns_none():
     planner = Planner(mock_rails, network)
 
     assert planner.compute_leg("a", "b") is None
+
+
+def test_compute_leg_curved_branch_requires_switch_path_b():
+    planner, network, switch = _planner_from_switch_y_with_markers()
+    approach = network.find_node_by_color("#ff0000")
+    exit_b = network.find_node_by_color("#0000ff")
+    assert approach and exit_b
+
+    leg = planner.compute_leg(approach, exit_b)
+    assert leg is not None
+    assert leg.required_switches == (RequiredSwitch(rail_id=switch.id, path_id="B"),)
+    assert all(rs.rail_id == switch.id for rs in leg.required_switches)
+
+
+def test_compute_leg_straight_branch_requires_switch_path_a():
+    planner, network, switch = _planner_from_switch_y_with_markers()
+    approach = network.find_node_by_color("#ff0000")
+    exit_a = network.find_node_by_color("#00ff00")
+    assert approach and exit_a
+
+    leg = planner.compute_leg(approach, exit_a)
+    assert leg is not None
+    assert leg.required_switches == (RequiredSwitch(rail_id=switch.id, path_id="A"),)
+
+
+def test_collect_required_switches_conflict_returns_none():
+    """Same switch rail with two path_ids on one path is an invalid leg."""
+    rails, switch = _make_switch_y_layout()
+    graph = nx.Graph()
+    graph.add_edge(
+        "n0",
+        "n1",
+        segment_data=[{"rail_id": switch.id, "path_id": "A", "from": 0, "to": 16}],
+    )
+    graph.add_edge(
+        "n1",
+        "n2",
+        segment_data=[{"rail_id": switch.id, "path_id": "B", "from": 0, "to": 16}],
+    )
+
+    assert collect_required_switches(rails, graph, ["n0", "n1", "n2"]) is None


### PR DESCRIPTION
## Summary
- Extend `LegResult` with `required_switches` derived from the chosen path's `segment_data` (switch rails only; pure API, no mutation).
- Conflicting path_ids on the same switch rail make the leg invalid (`None`).
- Unit tests cover curved branch → path `B`, straight → `A`, empty on linear track, and conflict detection.

Closes #133

## Test plan
- [x] `pytest tests/test_planner.py -v` (7 passed)
- [ ] CI green on this PR