### PR TITLE
C1.1: Run-mode order list panel

### DIFF
--- a/Controller/TrainsController.pyproject
+++ b/Controller/TrainsController.pyproject
@@ -71,6 +71,7 @@
         "src/qml/DiscoverDevices.qml",
         "src/qml/DevicesPanel.qml",
         "src/qml/TrainControlPanel.qml",
+        "src/qml/OrderListPanel.qml",
         "src/qml/TrackCanvas.qml",
         "src/qml/RailItem.qml",
         "src/qml/Globals.qml",

--- a/Controller/src/projects/rails.json
+++ b/Controller/src/projects/rails.json
@@ -452,8 +452,8 @@
         }
     ],
     "settings": {
-        "canvas_x": 154.0,
-        "canvas_y": 66.0,
+        "canvas_x": 369.0,
+        "canvas_y": 54.0,
         "canvas_zoom": 0.13
     }
 }

--- a/Controller/src/python/models/switch_devices.py
+++ b/Controller/src/python/models/switch_devices.py
@@ -19,8 +19,22 @@ class SwitchDevices(ObjectBasedModel[SwitchDevice]):
         self._rails = None
         self._rail_to_device: dict[int, SwitchDevice] = {}
         self._sim_counter = 0
+        self._bindings_revision = 0
 
     bindings_changed = Signal()
+    bindings_revision_changed = Signal()
+
+    def bindings_revision(self):
+        return self._bindings_revision
+
+    bindingsRevision = Property(
+        int, bindings_revision, notify=bindings_revision_changed
+    )
+
+    def _notify_bindings_changed(self):
+        self._bindings_revision += 1
+        self.bindings_revision_changed.emit()
+        self.bindings_changed.emit()
 
     def set_rails_model(self, rails):
         self.clear_bindings()
@@ -31,7 +45,7 @@ class SwitchDevices(ObjectBasedModel[SwitchDevice]):
             self._disconnect_rail_signals(device)
             device.set_bound_rail(None)
         self._rail_to_device.clear()
-        self.bindings_changed.emit()
+        self._notify_bindings_changed()
 
     def clear_all(self):
         """Clear bindings and remove all devices (e.g. project change)."""
@@ -74,7 +88,7 @@ class SwitchDevices(ObjectBasedModel[SwitchDevice]):
         self._disconnect_rail_signals(device)
         self._rail_to_device.pop(rail.id, None)
         device.set_bound_rail(None)
-        self.bindings_changed.emit()
+        self._notify_bindings_changed()
 
     @Slot(result=QObject)
     def addSimulated(self):
@@ -101,7 +115,7 @@ class SwitchDevices(ObjectBasedModel[SwitchDevice]):
         self._rail_to_device[rail.id] = device
         rail.switch_position_changed.connect(self._on_rail_position_changed)
         device.set_position(rail.switch_position)
-        self.bindings_changed.emit()
+        self._notify_bindings_changed()
 
     @Slot(QObject)
     def unbindRail(self, rail):

--- a/Controller/src/python/network_manager.py
+++ b/Controller/src/python/network_manager.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 from PySide6.QtCore import QObject, Slot, Property, Signal
+from PySide6.QtGui import QColor
 from python.network_generator import NetworkGenerator
 
 class NetworkManager(QObject):
@@ -125,6 +126,13 @@ class NetworkManager(QObject):
 
     def find_node_marker(self, node_id: str):
         return self._nodeMarkerMap.get(node_id)
+
+    @Slot(str, result=QColor)
+    def color_for_node(self, node_id: str) -> QColor:
+        marker = self.find_node_marker(node_id)
+        if marker is None or marker.color is None:
+            return QColor()
+        return marker.color
 
     def find_node_by_color(self, color_key: str):
         """color_key should be a lowercase hex string e.g. '#ff0000'"""

--- a/Controller/src/python/network_manager.py
+++ b/Controller/src/python/network_manager.py
@@ -123,6 +123,13 @@ class NetworkManager(QObject):
                 continue
             self._color_map[color_key] = node_id
         print(f"Network: Color map built with {len(self._color_map)} entries: {self._color_map}")
+        self.marker_node_ids_changed.emit()
+
+    def marker_node_ids(self):
+        return sorted(self._color_map.values())
+
+    marker_node_ids_changed = Signal()
+    markerNodeIds = Property("QStringList", marker_node_ids, notify=marker_node_ids_changed)
 
     def find_node_marker(self, node_id: str):
         return self._nodeMarkerMap.get(node_id)

--- a/Controller/src/qml/DevicesPanel.qml
+++ b/Controller/src/qml/DevicesPanel.qml
@@ -158,18 +158,10 @@ Item {
                             required property var object
                             required property int index
 
-                            property string boundDeviceName: object
-                                ? switchDevices.deviceNameForRail(object) : ""
-
                             width: switchRails.width
                             height: object && object.is_switch() ? 40 : 0
                             visible: height > 0
                             color: root.selectedRailIndex === index ? "#cce5ff" : "transparent"
-
-                            function refreshBoundDeviceName() {
-                                boundDeviceName = object
-                                    ? switchDevices.deviceNameForRail(object) : ""
-                            }
 
                             RowLayout {
                                 anchors.fill: parent
@@ -178,10 +170,13 @@ Item {
                                 visible: railRow.visible
 
                                 Text {
-                                    text: "Rail " + object.id
-                                          + " (" + (object.type === 2 ? "SwitchLeft" : "SwitchRight") + ")"
-                                          + "  pos " + object.switch_position
-                                          + "  —  " + railRow.boundDeviceName
+                                    text: {
+                                        var _ = switchDevices.bindingsRevision
+                                        return "Rail " + object.id
+                                              + " (" + (object.type === 2 ? "SwitchLeft" : "SwitchRight") + ")"
+                                              + "  pos " + object.switch_position
+                                              + "  —  " + (object ? switchDevices.deviceNameForRail(object) : "")
+                                    }
                                     Layout.fillWidth: true
                                 }
                             }
@@ -192,13 +187,6 @@ Item {
                                 onClicked: {
                                     root.selectedRailIndex = index
                                     root.selectedRail = object
-                                }
-                            }
-
-                            Connections {
-                                target: switchDevices
-                                function onBindings_changed() {
-                                    railRow.refreshBoundDeviceName()
                                 }
                             }
                         }

--- a/Controller/src/qml/DevicesPanel.qml
+++ b/Controller/src/qml/DevicesPanel.qml
@@ -171,8 +171,6 @@ Item {
                                     ? switchDevices.deviceNameForRail(object) : ""
                             }
 
-                            Component.onCompleted: refreshBoundDeviceName()
-
                             RowLayout {
                                 anchors.fill: parent
                                 anchors.margins: 4

--- a/Controller/src/qml/DevicesPanel.qml
+++ b/Controller/src/qml/DevicesPanel.qml
@@ -158,10 +158,20 @@ Item {
                             required property var object
                             required property int index
 
+                            property string boundDeviceName: object
+                                ? switchDevices.deviceNameForRail(object) : ""
+
                             width: switchRails.width
                             height: object && object.is_switch() ? 40 : 0
                             visible: height > 0
                             color: root.selectedRailIndex === index ? "#cce5ff" : "transparent"
+
+                            function refreshBoundDeviceName() {
+                                boundDeviceName = object
+                                    ? switchDevices.deviceNameForRail(object) : ""
+                            }
+
+                            Component.onCompleted: refreshBoundDeviceName()
 
                             RowLayout {
                                 anchors.fill: parent
@@ -173,7 +183,7 @@ Item {
                                     text: "Rail " + object.id
                                           + " (" + (object.type === 2 ? "SwitchLeft" : "SwitchRight") + ")"
                                           + "  pos " + object.switch_position
-                                          + "  —  " + switchDevices.deviceNameForRail(object)
+                                          + "  —  " + railRow.boundDeviceName
                                     Layout.fillWidth: true
                                 }
                             }
@@ -189,8 +199,8 @@ Item {
 
                             Connections {
                                 target: switchDevices
-                                function onBindingsChanged() {
-                                    railRow.visible = railRow.visible
+                                function onBindings_changed() {
+                                    railRow.refreshBoundDeviceName()
                                 }
                             }
                         }

--- a/Controller/src/qml/Globals.qml
+++ b/Controller/src/qml/Globals.qml
@@ -13,6 +13,7 @@ QtObject {
 
     property int selectedRail: Rail.Straight   // TODO - fix RailType registration
     property int selectedMarker: -1
+    property int planningTrainIndex: 0
 
     property Item globalArea: null
 

--- a/Controller/src/qml/OrderListPanel.qml
+++ b/Controller/src/qml/OrderListPanel.qml
@@ -19,7 +19,7 @@ Item {
         Text {
             text: {
                 var mode = root.train.control_mode === Train.Automatic ? "Automatic" : "Manual"
-                return "Orders idx " + root.train.current_order_index + " · " + mode
+                return "Current stop: " + root.train.current_order_index + " · " + mode
             }
             font.bold: true
             Layout.fillWidth: true
@@ -62,13 +62,25 @@ Item {
                     Layout.fillWidth: true
                 }
 
+                Text {
+                    text: "wait"
+                    font.pixelSize: 11
+                    color: palette.mid
+                }
+
                 SpinBox {
                     id: waitSpin
                     from: 0
                     to: 999
                     editable: true
                     value: Math.round(object.wait_seconds)
-                    Layout.preferredWidth: 70
+                    Layout.preferredWidth: 72
+                    ToolTip.visible: hovered
+                    ToolTip.text: "Seconds to wait at this stop"
+                    textFromValue: function(value, locale) { return value + "s" }
+                    valueFromText: function(text, locale) {
+                        return parseInt(String(text).replace("s", ""), 10) || 0
+                    }
                     onValueModified: root.train.set_wait(index, value)
                 }
 
@@ -98,19 +110,76 @@ Item {
             Layout.fillWidth: true
             spacing: 4
 
-            TextField {
-                id: debugNodeId
-                placeholderText: "node id"
+            ComboBox {
+                id: markerPick
                 Layout.fillWidth: true
+                model: network.markerNodeIds
+                enabled: count > 0
+                currentIndex: count > 0 ? 0 : -1
+
+                displayText: {
+                    if (count === 0)
+                        return "No markers"
+                    if (currentIndex < 0)
+                        return "Select marker…"
+                    return currentText
+                }
+
+                delegate: ItemDelegate {
+                    required property var modelData
+                    required property int index
+                    width: markerPick.width
+                    highlighted: markerPick.highlightedIndex === index
+
+                    contentItem: RowLayout {
+                        spacing: 6
+
+                        Rectangle {
+                            property color nodeColor: network.color_for_node(modelData)
+                            visible: nodeColor.valid
+                            color: nodeColor
+                            border.width: 1
+                            Layout.preferredWidth: 12
+                            Layout.preferredHeight: 12
+                        }
+
+                        Text {
+                            text: modelData
+                            elide: Text.ElideRight
+                            Layout.fillWidth: true
+                        }
+                    }
+                }
+
+                contentItem: RowLayout {
+                    spacing: 6
+                    leftPadding: 8
+                    rightPadding: markerPick.indicator.width + 8
+
+                    Rectangle {
+                        property color nodeColor: markerPick.currentIndex >= 0
+                            ? network.color_for_node(markerPick.currentText)
+                            : "transparent"
+                        visible: markerPick.currentIndex >= 0 && nodeColor.valid
+                        color: nodeColor
+                        border.width: 1
+                        Layout.preferredWidth: 12
+                        Layout.preferredHeight: 12
+                    }
+
+                    Text {
+                        text: markerPick.displayText
+                        elide: Text.ElideRight
+                        Layout.fillWidth: true
+                        verticalAlignment: Text.AlignVCenter
+                    }
+                }
             }
 
             Button {
                 text: "Add"
-                enabled: debugNodeId.text.trim().length > 0
-                onClicked: {
-                    root.train.add_order(debugNodeId.text.trim(), 0)
-                    debugNodeId.text = ""
-                }
+                enabled: markerPick.currentIndex >= 0 && markerPick.count > 0
+                onClicked: root.train.add_order(markerPick.currentText, 0)
             }
 
             Button {
@@ -118,6 +187,15 @@ Item {
                 enabled: root.train.orders.count > 0
                 onClicked: root.train.clear_orders()
             }
+        }
+
+        Text {
+            visible: network.markerNodeIds.length === 0
+            text: "Generate network to list markers"
+            font.pixelSize: 11
+            color: palette.mid
+            Layout.fillWidth: true
+            wrapMode: Text.WordWrap
         }
     }
 }

--- a/Controller/src/qml/OrderListPanel.qml
+++ b/Controller/src/qml/OrderListPanel.qml
@@ -1,0 +1,123 @@
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
+import TrainView
+
+Item {
+    id: root
+
+    property Train train
+
+    implicitHeight: column.implicitHeight
+    implicitWidth: 220
+
+    ColumnLayout {
+        id: column
+        anchors.fill: parent
+        spacing: 4
+
+        Text {
+            text: {
+                var mode = root.train.control_mode === Train.Automatic ? "Automatic" : "Manual"
+                return "Orders idx " + root.train.current_order_index + " · " + mode
+            }
+            font.bold: true
+            Layout.fillWidth: true
+            wrapMode: Text.WordWrap
+        }
+
+        ListView {
+            id: orderView
+            Layout.fillWidth: true
+            Layout.preferredHeight: Math.min(160, Math.max(40, root.train.orders.count * 36))
+            clip: true
+            model: root.train.orders
+            spacing: 2
+
+            delegate: RowLayout {
+                width: orderView.width
+                height: 34
+                spacing: 2
+
+                required property var object
+                required property int index
+
+                Text {
+                    text: index === root.train.current_order_index ? "\u25B6" : " "
+                    Layout.preferredWidth: 14
+                }
+
+                Rectangle {
+                    property color nodeColor: network.color_for_node(object.target_node_id)
+                    visible: nodeColor.valid
+                    color: nodeColor
+                    border.width: 1
+                    Layout.preferredWidth: 14
+                    Layout.preferredHeight: 14
+                }
+
+                Text {
+                    text: object.target_node_id
+                    elide: Text.ElideRight
+                    Layout.fillWidth: true
+                }
+
+                SpinBox {
+                    id: waitSpin
+                    from: 0
+                    to: 999
+                    editable: true
+                    value: Math.round(object.wait_seconds)
+                    Layout.preferredWidth: 70
+                    onValueModified: root.train.set_wait(index, value)
+                }
+
+                Button {
+                    text: "\u2191"
+                    enabled: index > 0
+                    Layout.preferredWidth: 28
+                    onClicked: root.train.move_order(index, index - 1)
+                }
+
+                Button {
+                    text: "\u2193"
+                    enabled: index < root.train.orders.count - 1
+                    Layout.preferredWidth: 28
+                    onClicked: root.train.move_order(index, index + 1)
+                }
+
+                Button {
+                    text: "X"
+                    Layout.preferredWidth: 28
+                    onClicked: root.train.remove_order(index)
+                }
+            }
+        }
+
+        RowLayout {
+            Layout.fillWidth: true
+            spacing: 4
+
+            TextField {
+                id: debugNodeId
+                placeholderText: "node id"
+                Layout.fillWidth: true
+            }
+
+            Button {
+                text: "Add"
+                enabled: debugNodeId.text.trim().length > 0
+                onClicked: {
+                    root.train.add_order(debugNodeId.text.trim(), 0)
+                    debugNodeId.text = ""
+                }
+            }
+
+            Button {
+                text: "Clear"
+                enabled: root.train.orders.count > 0
+                onClicked: root.train.clear_orders()
+            }
+        }
+    }
+}

--- a/Controller/src/qml/OrderListPanel.qml
+++ b/Controller/src/qml/OrderListPanel.qml
@@ -151,27 +151,32 @@ Item {
                     }
                 }
 
-                contentItem: RowLayout {
-                    spacing: 6
-                    leftPadding: 8
-                    rightPadding: markerPick.indicator.width + 8
+                contentItem: Item {
+                    implicitHeight: 24
 
-                    Rectangle {
-                        property color nodeColor: markerPick.currentIndex >= 0
-                            ? network.color_for_node(markerPick.currentText)
-                            : "transparent"
-                        visible: markerPick.currentIndex >= 0 && nodeColor.valid
-                        color: nodeColor
-                        border.width: 1
-                        Layout.preferredWidth: 12
-                        Layout.preferredHeight: 12
-                    }
+                    RowLayout {
+                        anchors.fill: parent
+                        anchors.leftMargin: 8
+                        anchors.rightMargin: markerPick.indicator.width + 8
+                        spacing: 6
 
-                    Text {
-                        text: markerPick.displayText
-                        elide: Text.ElideRight
-                        Layout.fillWidth: true
-                        verticalAlignment: Text.AlignVCenter
+                        Rectangle {
+                            property color nodeColor: markerPick.currentIndex >= 0
+                                ? network.color_for_node(markerPick.currentText)
+                                : "transparent"
+                            visible: markerPick.currentIndex >= 0 && nodeColor.valid
+                            color: nodeColor
+                            border.width: 1
+                            Layout.preferredWidth: 12
+                            Layout.preferredHeight: 12
+                        }
+
+                        Text {
+                            text: markerPick.displayText
+                            elide: Text.ElideRight
+                            Layout.fillWidth: true
+                            verticalAlignment: Text.AlignVCenter
+                        }
                     }
                 }
             }

--- a/Controller/src/qml/OrderListPanel.qml
+++ b/Controller/src/qml/OrderListPanel.qml
@@ -16,12 +16,36 @@ Item {
         anchors.fill: parent
         spacing: 4
 
-        Text {
-            text: {
-                var mode = root.train.control_mode === Train.Automatic ? "Automatic" : "Manual"
-                return "Current stop: " + root.train.current_order_index + " · " + mode
+        RowLayout {
+            Layout.fillWidth: true
+            spacing: 6
+
+            Text {
+                text: "Current stop: " + root.train.current_order_index
+                font.bold: true
+                Layout.fillWidth: true
+                wrapMode: Text.WordWrap
             }
-            font.bold: true
+
+            Text {
+                text: root.train.control_mode === Train.Automatic ? "Auto" : "Manual"
+                font.bold: true
+            }
+
+            Switch {
+                id: modeSwitch
+                checked: root.train.control_mode === Train.Automatic
+                onToggled: {
+                    root.train.control_mode = checked ? Train.Automatic : Train.Manual
+                }
+            }
+        }
+
+        Text {
+            visible: root.train.control_mode === Train.Automatic
+            text: "Auto (executor not ready)"
+            font.pixelSize: 11
+            color: palette.mid
             Layout.fillWidth: true
             wrapMode: Text.WordWrap
         }

--- a/Controller/src/qml/RunPanel.qml
+++ b/Controller/src/qml/RunPanel.qml
@@ -6,6 +6,7 @@ Item {
         anchors.top: parent.top
         anchors.right: parent.right
         spacing: 2
+        z: 1
 
         Button {
             text: simulator.is_running ? "\u23F9 Stop Simulation" : "\u25B6 Simulate"
@@ -19,16 +20,31 @@ Item {
 
         anchors.top: parent.top
         anchors.left: parent.left
-        height: trains.count > 0 ? Math.min(300, parent.height) : 0
-        width: trains.count > 0 ? Math.min(trains.count * 160, parent.width * 0.5) : 0
+        height: trains.count > 0 ? Math.min(420, parent.height) : 0
+        width: trains.count > 0 ? Math.min(trains.count * 250, parent.width * 0.55) : 0
 
         model: trains
         orientation: Qt.Horizontal
         spacing: 5
+        currentIndex: Globals.planningTrainIndex
+        clip: true
 
         delegate: TrainControlPanel {
             height: trainView.height
-            width: 150
+            width: 240
+            trainIndex: index
+        }
+
+        Connections {
+            target: trains
+            function onCountChanged() {
+                if (trains.count === 0) {
+                    Globals.planningTrainIndex = 0
+                    return
+                }
+                if (Globals.planningTrainIndex >= trains.count)
+                    Globals.planningTrainIndex = trains.count - 1
+            }
         }
     }
 }

--- a/Controller/src/qml/TrainControlPanel.qml
+++ b/Controller/src/qml/TrainControlPanel.qml
@@ -8,72 +8,110 @@ Item {
 
     property Train train: model.object
     property var device: root.train.device
+    property int trainIndex: 0
 
-    GroupBox {
-        title: root.device.name
-        enabled: root.device.initialized
+    readonly property bool isPlanningTarget: Globals.planningTrainIndex === trainIndex
 
-        ColumnLayout {
-            anchors.fill: parent
+    Rectangle {
+        anchors.fill: parent
+        color: root.isPlanningTarget ? "#cce5ff" : "transparent"
+        border.color: root.isPlanningTarget ? "#6699cc" : "transparent"
+        border.width: 2
+        radius: 4
+    }
 
-            Text {
-                text: "Speed " + speedSlider.value
-                Layout.alignment: Qt.AlignHCenter
-            }
+    function selectAsPlanningTarget() {
+        Globals.planningTrainIndex = root.trainIndex
+        if (ListView.view)
+            ListView.view.currentIndex = root.trainIndex
+    }
 
-            Slider {
-                id: speedSlider
+    TapHandler {
+        acceptedButtons: Qt.LeftButton
+        gesturePolicy: TapHandler.DragThreshold
+        onTapped: root.selectAsPlanningTarget()
+    }
 
-                value: root.device.speed
-                orientation: Qt.Vertical
-                wheelEnabled: true
-                from: root.device.minimalSpeed
-                to: 100
-                stepSize: 10
-                snapMode: Slider.SnapAlways
+    ScrollView {
+        anchors.fill: parent
+        anchors.margins: 2
+        contentWidth: availableWidth
+        clip: true
 
-                Layout.alignment: Qt.AlignHCenter
+        GroupBox {
+            title: root.device.name + (root.isPlanningTarget ? " (planning)" : "")
+            enabled: root.device.initialized
+            width: root.width - 8
 
-                Binding {
-                    target: root.device
-                    property: "speed"
-                    value: speedSlider.value
+            ColumnLayout {
+                width: parent.width
+                spacing: 4
+
+                Text {
+                    text: "Speed " + speedSlider.value
+                    Layout.alignment: Qt.AlignHCenter
                 }
-            }
 
-            Button {
-                text: "Stop"
-                onClicked: speedSlider.value = 0
-                Layout.fillWidth: true
-            }
+                Slider {
+                    id: speedSlider
 
-            Text {
-                text: "Voltage " + (root.device.voltage / 1000).toFixed(1) + " V"
-                Layout.alignment: Qt.AlignHCenter
-            }
+                    value: root.device.speed
+                    orientation: Qt.Vertical
+                    wheelEnabled: true
+                    from: root.device.minimalSpeed
+                    to: 100
+                    stepSize: 10
+                    snapMode: Slider.SnapAlways
 
-            Rectangle {
-                id: detectedColor
-                border.width: 2
-                color: root.device.color
+                    Layout.alignment: Qt.AlignHCenter
+                    Layout.preferredHeight: 80
 
-                Layout.preferredHeight: 50
-                Layout.preferredWidth: 50
-                Layout.alignment: Qt.AlignHCenter
-            }
+                    Binding {
+                        target: root.device
+                        property: "speed"
+                        value: speedSlider.value
+                    }
+                }
 
-            Text {
-                text: "Segment:"
-                font.bold: true
-                Layout.alignment: Qt.AlignHCenter
-            }
+                Button {
+                    text: "Stop"
+                    onClicked: speedSlider.value = 0
+                    Layout.fillWidth: true
+                }
 
-            Text {
-                text: root.train.current_segment_id || "unknown"
-                wrapMode: Text.WrapAnywhere
-                horizontalAlignment: Text.AlignHCenter
-                Layout.fillWidth: true
-                Layout.maximumWidth: root.width
+                Text {
+                    text: "Voltage " + (root.device.voltage / 1000).toFixed(1) + " V"
+                    Layout.alignment: Qt.AlignHCenter
+                }
+
+                Rectangle {
+                    id: detectedColor
+                    border.width: 2
+                    color: root.device.color
+
+                    Layout.preferredHeight: 36
+                    Layout.preferredWidth: 36
+                    Layout.alignment: Qt.AlignHCenter
+                }
+
+                Text {
+                    text: "Segment:"
+                    font.bold: true
+                    Layout.alignment: Qt.AlignHCenter
+                }
+
+                Text {
+                    text: root.train.current_segment_id || "unknown"
+                    wrapMode: Text.WrapAnywhere
+                    horizontalAlignment: Text.AlignHCenter
+                    Layout.fillWidth: true
+                }
+
+                OrderListPanel {
+                    train: root.train
+                    Layout.fillWidth: true
+                    Layout.preferredHeight: implicitHeight
+                }
             }
         }
     }

--- a/Controller/tests/test_network_manager.py
+++ b/Controller/tests/test_network_manager.py
@@ -289,3 +289,19 @@ def test_find_segments_to_next_marker_covers_switch():
     assert segments_b != segments_a
     assert exit_b_node in segments_b[-1]
     assert net_manager.find_next_marker_node(approach_node) == exit_b_node
+
+
+def test_color_for_node():
+    from python.items.marker import Marker
+
+    mock_rails = MagicMock()
+    mock_rails.items.return_value = []
+    net_manager = net.NetworkManager(mock_rails)
+
+    red = QColor("#ff0000")
+    marker = Marker(color=red)
+    net_manager._nodeMarkerMap["1A10"] = marker
+
+    assert net_manager.color_for_node("1A10") == red
+    assert not net_manager.color_for_node("missing").isValid()
+    assert not net_manager.color_for_node("").isValid()

--- a/Controller/tests/test_network_manager.py
+++ b/Controller/tests/test_network_manager.py
@@ -305,3 +305,17 @@ def test_color_for_node():
     assert net_manager.color_for_node("1A10") == red
     assert not net_manager.color_for_node("missing").isValid()
     assert not net_manager.color_for_node("").isValid()
+
+
+def test_marker_node_ids():
+    mock_rails = MagicMock()
+    mock_rails.items.return_value = []
+    net_manager = net.NetworkManager(mock_rails)
+
+    assert net_manager.markerNodeIds == []
+
+    net_manager._color_map = {
+        "#ff0000": "2B20",
+        "#00ff00": "1A10",
+    }
+    assert net_manager.marker_node_ids() == ["1A10", "2B20"]

--- a/Controller/tests/test_switch_device.py
+++ b/Controller/tests/test_switch_device.py
@@ -52,10 +52,13 @@ def test_unbind_and_reassign():
 
     devices.assignToRail(rail_a, device)
     assert devices.deviceNameForRail(rail_a) == device.name
+    revision_after_assign = devices.bindingsRevision
+    assert revision_after_assign > 0
 
     devices.unbindRail(rail_a)
     assert devices.deviceForRail(rail_a) is None
     assert device.bound_rail is None
+    assert devices.bindingsRevision > revision_after_assign
 
     devices.assignToRail(rail_b, device)
     assert devices.deviceForRail(rail_b) is device


### PR DESCRIPTION
## Summary
- Add Run-mode order list UI (`OrderListPanel`) on each train: list/edit wait, reorder, clear, planning-target selection
- Marker ComboBox from `network.markerNodeIds` + color swatches; clearer wait labels
- UI-only Manual/Auto switch (defaults to Automatic); does not drive motion until B1.2/B2
- Fix DevicesPanel `bindings_changed` QML Connections warning

Closes #140

## Notes for follow-ups
- Manual/Auto **toggle UI already landed here** — B2 (#139) should wire executor behavior (slider disable, reject empty orders, start/pause), not re-add the switch
- B1.2 (#138) still owns wait-at-stop / Hold / looping execution

## Test plan
- [ ] Run mode: Simulate → order panel appears; Add from marker dropdown; edit wait / reorder / remove / clear
- [ ] Color swatch matches marker; planning-target highlight works across trains
- [ ] Auto switch toggles label + “executor not ready” hint; sim still ignores orders
- [ ] Load a track with switches: no `onBindingsChanged` warning spam on Devices tab
- [ ] `pytest Controller/tests/test_network_manager.py Controller/tests/test_train_orders.py`
