### PR TITLE
A3.1: segment ownership for interlocking

### DIFF
--- a/Controller/src/python/items/train.py
+++ b/Controller/src/python/items/train.py
@@ -55,12 +55,15 @@ class Train(QObject):
         if not new_segment_ids or end_node is None:
             return
 
-        self._network.unreserve_segments(self._current_segment_ids)
-        self._network.reserve_segments(new_segment_ids)
+        owner = self._device.name
+        for segment_id in self._current_segment_ids:
+            self._network.release_segment(segment_id, owner)
+        for segment_id in new_segment_ids:
+            self._network.try_reserve_segment(segment_id, owner)
 
         self.set_current_node_id(node_id)
         self.set_current_segment_ids(new_segment_ids, f"{node_id}:{end_node}")
-        print(f"Train '{self._device.name}': reserved {new_segment_ids} via node {node_id}")
+        print(f"Train '{owner}': reserved {new_segment_ids} via node {node_id}")
 
     def device(self):
         return self._device

--- a/Controller/src/python/network_manager.py
+++ b/Controller/src/python/network_manager.py
@@ -13,6 +13,7 @@ class NetworkManager(QObject):
         self._graph = None
         self._nodeMarkerMap = {}
         self._segments = {} # lookup table
+        self._owners = {}  # segment_id -> owner_id; missing key = free
         self._color_map = {} # color hex -> node_id
         self._has_graph = False
         self._marker_warnings = []
@@ -25,6 +26,9 @@ class NetworkManager(QObject):
 
     def segments(self):
         return self._segments
+
+    def owner_of(self, segment_id) -> str | None:
+        return self._owners.get(segment_id)
 
     def _apply_to_segment(self, segment_id, fn) -> bool:
         if segment_id not in self._segments:
@@ -52,6 +56,39 @@ class NetworkManager(QObject):
                 lambda rail, path_id, from_d, to_d: rail.unreserve_segment(path_id, from_d, to_d)
             )
         return False
+
+    def try_reserve_segment(self, segment_id, owner) -> bool:
+        if not segment_id or not owner:
+            return False
+        if segment_id not in self._segments:
+            print(f"segment {segment_id} not found")
+            return False
+
+        current = self._owners.get(segment_id)
+        if current is not None and current != owner:
+            return False
+        if current == owner:
+            return True
+
+        if not self.reserve(segment_id):
+            return False
+        self._owners[segment_id] = owner
+        return True
+
+    def release_segment(self, segment_id, owner) -> bool:
+        if not segment_id or not owner:
+            return False
+        if self._owners.get(segment_id) != owner:
+            return False
+
+        del self._owners[segment_id]
+        return self.unreserve(segment_id)
+
+    def release_all_for(self, owner) -> None:
+        if not owner:
+            return
+        for segment_id in [sid for sid, o in self._owners.items() if o == owner]:
+            self.release_segment(segment_id, owner)
 
     def reserve_segments(self, segment_ids) -> bool:
         ok = True
@@ -290,6 +327,7 @@ class NetworkManager(QObject):
     @Slot()
     def generate(self):
         self._segments = {}
+        self._owners = {}
         self._graph, self._nodeMarkerMap = self._generator.generate(self._rails.items(), True)
 
         edges = self._graph.edges(data=True)

--- a/Controller/src/python/simulator.py
+++ b/Controller/src/python/simulator.py
@@ -113,8 +113,8 @@ class Simulator(QObject):
         self._current_node_id = None
         self._previous_node_id = None
 
-        if self._train and self._train._current_segment_ids:
-            self._network.unreserve_segments(self._train._current_segment_ids)
+        if self._train:
+            self._network.release_all_for(self._train.device.name)
 
         if self._sim_device:
             self._trains.remove_by_device(self._sim_device)

--- a/Controller/tests/test_segment_ownership.py
+++ b/Controller/tests/test_segment_ownership.py
@@ -1,0 +1,80 @@
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+from PySide6.QtWidgets import QApplication
+
+import python.network_manager as net
+import python.models.project_storage as project
+from python.items.rail import Rail
+
+TEST_TRACK = "tests/tracks/rails.json"
+SEGMENT_ID = "3A16:6A8"
+
+
+@pytest.fixture(scope="session", autouse=True)
+def ensure_qapp():
+    app = QApplication.instance() or QApplication([])
+    yield app
+
+
+@pytest.fixture
+def net_manager():
+    data = project.loadDataFromFile(Path(TEST_TRACK))
+    rails = [Rail.load_data(d) for d in data.get("rails", [])]
+    mock_rails = MagicMock()
+    mock_rails.items.return_value = rails
+    manager = net.NetworkManager(mock_rails)
+    manager.generate()
+    return manager
+
+
+def test_two_owners_cannot_hold_same_segment(net_manager):
+    assert net_manager.try_reserve_segment(SEGMENT_ID, "train-a")
+    assert net_manager.owner_of(SEGMENT_ID) == "train-a"
+    assert not net_manager.try_reserve_segment(SEGMENT_ID, "train-b")
+    assert net_manager.owner_of(SEGMENT_ID) == "train-a"
+
+
+def test_same_owner_rereserve_is_idempotent(net_manager):
+    assert net_manager.try_reserve_segment(SEGMENT_ID, "train-a")
+    assert net_manager.try_reserve_segment(SEGMENT_ID, "train-a")
+    assert net_manager.owner_of(SEGMENT_ID) == "train-a"
+
+
+def test_only_owner_can_release(net_manager):
+    assert net_manager.try_reserve_segment(SEGMENT_ID, "train-a")
+    assert not net_manager.release_segment(SEGMENT_ID, "train-b")
+    assert net_manager.owner_of(SEGMENT_ID) == "train-a"
+
+    assert net_manager.release_segment(SEGMENT_ID, "train-a")
+    assert net_manager.owner_of(SEGMENT_ID) is None
+    assert net_manager.try_reserve_segment(SEGMENT_ID, "train-b")
+    assert net_manager.owner_of(SEGMENT_ID) == "train-b"
+
+
+def test_release_all_for_frees_owner_segments(net_manager):
+    segment_ids = list(net_manager.segments().keys())[:2]
+    assert len(segment_ids) == 2
+
+    for segment_id in segment_ids:
+        assert net_manager.try_reserve_segment(segment_id, "train-a")
+    other = [sid for sid in net_manager.segments() if sid not in segment_ids][0]
+    assert net_manager.try_reserve_segment(other, "train-b")
+
+    net_manager.release_all_for("train-a")
+
+    for segment_id in segment_ids:
+        assert net_manager.owner_of(segment_id) is None
+    assert net_manager.owner_of(other) == "train-b"
+
+
+def test_try_reserve_unknown_segment_fails(net_manager):
+    assert not net_manager.try_reserve_segment("XXX", "train-a")
+    assert net_manager.owner_of("XXX") is None
+
+
+def test_generate_clears_owners(net_manager):
+    assert net_manager.try_reserve_segment(SEGMENT_ID, "train-a")
+    net_manager.generate()
+    assert net_manager.owner_of(SEGMENT_ID) is None


### PR DESCRIPTION
## Summary
- Add per-segment ownership on `NetworkManager` (`try_reserve_segment` / `release_segment` / `release_all_for`) so at most one train can hold a segment
- Wire Train occupancy and Simulator stop through the ownership API using `device.name` as owner id
- Add unit tests for ownership conflicts, idempotent re-reserve, and release rules

Closes #135

## Test plan
- [x] `pytest` in `Controller/` (70 passed)
- [ ] Manual: run simulator, confirm reservation paint still appears on occupied segments
- [ ] Manual: stop simulator, confirm reservations clear