### PR TITLE
fix: silence QML null TypeErrors on shutdown

### DIFF
--- a/Controller/src/main.py
+++ b/Controller/src/main.py
@@ -4,7 +4,6 @@ import resources.rails_rc
 
 from PySide6.QtGui import QGuiApplication
 from PySide6.QtQml import QQmlApplicationEngine
-from PySide6.QtQuickControls2 import QQuickStyle
 from qasync import QEventLoop
 from pathlib import Path
 import asyncio
@@ -20,7 +19,6 @@ if __name__ == '__main__':
     app = QGuiApplication(sys.argv)
     QGuiApplication.setOrganizationName("arProjects")
     QGuiApplication.setApplicationName("Lego Trains Controller")
-    QQuickStyle.setStyle("Fusion")
     loop = QEventLoop(app)
     asyncio.set_event_loop(loop)
 

--- a/Controller/src/main.py
+++ b/Controller/src/main.py
@@ -4,6 +4,7 @@ import resources.rails_rc
 
 from PySide6.QtGui import QGuiApplication
 from PySide6.QtQml import QQmlApplicationEngine
+from PySide6.QtQuickControls2 import QQuickStyle
 from qasync import QEventLoop
 from pathlib import Path
 import asyncio
@@ -19,6 +20,7 @@ if __name__ == '__main__':
     app = QGuiApplication(sys.argv)
     QGuiApplication.setOrganizationName("arProjects")
     QGuiApplication.setApplicationName("Lego Trains Controller")
+    QQuickStyle.setStyle("Fusion")
     loop = QEventLoop(app)
     asyncio.set_event_loop(loop)
 
@@ -33,3 +35,6 @@ if __name__ == '__main__':
 
     with loop:  # TODO - why not to use app.exec()
         loop.run_forever()
+
+    # Destroy QML while AppContext (and its context properties) still exist.
+    del engine

--- a/Controller/src/qml/DevicesPanel.qml
+++ b/Controller/src/qml/DevicesPanel.qml
@@ -171,11 +171,15 @@ Item {
 
                                 Text {
                                     text: {
-                                        var _ = switchDevices.bindingsRevision
+                                        var _ = switchDevices ? switchDevices.bindingsRevision : 0
+                                        if (!object)
+                                            return ""
                                         return "Rail " + object.id
                                               + " (" + (object.type === 2 ? "SwitchLeft" : "SwitchRight") + ")"
                                               + "  pos " + object.switch_position
-                                              + "  —  " + (object ? switchDevices.deviceNameForRail(object) : "")
+                                              + "  —  " + (switchDevices
+                                                  ? switchDevices.deviceNameForRail(object)
+                                                  : "")
                                     }
                                     Layout.fillWidth: true
                                 }
@@ -196,6 +200,7 @@ Item {
                         Button {
                             text: "Assign"
                             enabled: root.selectedRail !== null
+                                     && switchDevices
                                      && switchDevices.deviceForRail(root.selectedRail) === null
                                      && switchDevices.unboundDevices().length > 0
                             onClicked: assignDialog.open()
@@ -203,8 +208,12 @@ Item {
                         Button {
                             text: "Unbind"
                             enabled: root.selectedRail !== null
+                                     && switchDevices
                                      && switchDevices.deviceForRail(root.selectedRail) !== null
-                            onClicked: switchDevices.unbindRail(root.selectedRail)
+                            onClicked: {
+                                if (switchDevices)
+                                    switchDevices.unbindRail(root.selectedRail)
+                            }
                         }
                         Item { Layout.fillWidth: true }
                     }

--- a/Controller/src/qml/MultiPathView.qml
+++ b/Controller/src/qml/MultiPathView.qml
@@ -6,7 +6,7 @@ Item {
     property var model
 
     Repeater {
-        model: root.model.multiPathIndicators
+        model: root.model ? root.model.multiPathIndicators : null
 
         delegate: Item {
             id: item
@@ -17,11 +17,12 @@ Item {
 
             PathIndicatorView {
                 anchors.fill: parent
-                visible: root.model.path_id_active === item.indicator.path_id
+                visible: item.indicator && root.model
+                         && root.model.path_id_active === item.indicator.path_id
                 model: PathIndicatorsFilter {
                     id: filter
                     sourceModel: root.model // TODO - it's a bit confusing to use the same model as above
-                    path_id: item.indicator.path_id
+                    path_id: item.indicator ? item.indicator.path_id : ""
                 }
             }
         }

--- a/Controller/src/qml/OrderListPanel.qml
+++ b/Controller/src/qml/OrderListPanel.qml
@@ -154,6 +154,19 @@ Item {
             Layout.fillWidth: true
             spacing: 4
 
+            // Color swatch outside ComboBox — native Windows style forbids
+            // customizing ComboBox/ItemDelegate contentItem.
+            Rectangle {
+                property color nodeColor: markerPick.currentIndex >= 0 && network
+                    ? network.color_for_node(markerPick.currentText)
+                    : "transparent"
+                visible: markerPick.currentIndex >= 0 && nodeColor.valid
+                color: nodeColor
+                border.width: 1
+                Layout.preferredWidth: 12
+                Layout.preferredHeight: 12
+            }
+
             ComboBox {
                 id: markerPick
                 Layout.fillWidth: true
@@ -173,59 +186,8 @@ Item {
                     required property var modelData
                     required property int index
                     width: markerPick.width
+                    text: modelData
                     highlighted: markerPick.highlightedIndex === index
-
-                    contentItem: RowLayout {
-                        spacing: 6
-
-                        Rectangle {
-                            property color nodeColor: network
-                                ? network.color_for_node(modelData)
-                                : "transparent"
-                            visible: nodeColor.valid
-                            color: nodeColor
-                            border.width: 1
-                            Layout.preferredWidth: 12
-                            Layout.preferredHeight: 12
-                        }
-
-                        Text {
-                            text: modelData
-                            elide: Text.ElideRight
-                            Layout.fillWidth: true
-                        }
-                    }
-                }
-
-                contentItem: Item {
-                    implicitHeight: 24
-
-                    RowLayout {
-                        anchors.fill: parent
-                        anchors.leftMargin: 8
-                        anchors.rightMargin: markerPick.indicator
-                            ? markerPick.indicator.width + 8
-                            : 8
-                        spacing: 6
-
-                        Rectangle {
-                            property color nodeColor: markerPick.currentIndex >= 0 && network
-                                ? network.color_for_node(markerPick.currentText)
-                                : "transparent"
-                            visible: markerPick.currentIndex >= 0 && nodeColor.valid
-                            color: nodeColor
-                            border.width: 1
-                            Layout.preferredWidth: 12
-                            Layout.preferredHeight: 12
-                        }
-
-                        Text {
-                            text: markerPick.displayText
-                            elide: Text.ElideRight
-                            Layout.fillWidth: true
-                            verticalAlignment: Text.AlignVCenter
-                        }
-                    }
                 }
             }
 

--- a/Controller/src/qml/OrderListPanel.qml
+++ b/Controller/src/qml/OrderListPanel.qml
@@ -15,34 +15,37 @@ Item {
         id: column
         anchors.fill: parent
         spacing: 4
+        enabled: root.train !== null
 
         RowLayout {
             Layout.fillWidth: true
             spacing: 6
 
             Text {
-                text: "Current stop: " + root.train.current_order_index
+                text: "Current stop: " + (root.train ? root.train.current_order_index : 0)
                 font.bold: true
                 Layout.fillWidth: true
                 wrapMode: Text.WordWrap
             }
 
             Text {
-                text: root.train.control_mode === Train.Automatic ? "Auto" : "Manual"
+                text: root.train && root.train.control_mode === Train.Automatic ? "Auto" : "Manual"
                 font.bold: true
             }
 
             Switch {
                 id: modeSwitch
-                checked: root.train.control_mode === Train.Automatic
+                checked: root.train && root.train.control_mode === Train.Automatic
                 onToggled: {
+                    if (!root.train)
+                        return
                     root.train.control_mode = checked ? Train.Automatic : Train.Manual
                 }
             }
         }
 
         Text {
-            visible: root.train.control_mode === Train.Automatic
+            visible: root.train && root.train.control_mode === Train.Automatic
             text: "Auto (executor not ready)"
             font.pixelSize: 11
             color: palette.mid
@@ -53,9 +56,12 @@ Item {
         ListView {
             id: orderView
             Layout.fillWidth: true
-            Layout.preferredHeight: Math.min(160, Math.max(40, root.train.orders.count * 36))
+            Layout.preferredHeight: Math.min(
+                160,
+                Math.max(40, root.train ? root.train.orders.count * 36 : 40)
+            )
             clip: true
-            model: root.train.orders
+            model: root.train ? root.train.orders : null
             spacing: 2
 
             delegate: RowLayout {
@@ -67,12 +73,14 @@ Item {
                 required property int index
 
                 Text {
-                    text: index === root.train.current_order_index ? "\u25B6" : " "
+                    text: root.train && index === root.train.current_order_index ? "\u25B6" : " "
                     Layout.preferredWidth: 14
                 }
 
                 Rectangle {
-                    property color nodeColor: network.color_for_node(object.target_node_id)
+                    property color nodeColor: network && object
+                        ? network.color_for_node(object.target_node_id)
+                        : "transparent"
                     visible: nodeColor.valid
                     color: nodeColor
                     border.width: 1
@@ -81,7 +89,7 @@ Item {
                 }
 
                 Text {
-                    text: object.target_node_id
+                    text: object ? object.target_node_id : ""
                     elide: Text.ElideRight
                     Layout.fillWidth: true
                 }
@@ -97,7 +105,7 @@ Item {
                     from: 0
                     to: 999
                     editable: true
-                    value: Math.round(object.wait_seconds)
+                    value: object ? Math.round(object.wait_seconds) : 0
                     Layout.preferredWidth: 72
                     ToolTip.visible: hovered
                     ToolTip.text: "Seconds to wait at this stop"
@@ -105,27 +113,39 @@ Item {
                     valueFromText: function(text, locale) {
                         return parseInt(String(text).replace("s", ""), 10) || 0
                     }
-                    onValueModified: root.train.set_wait(index, value)
+                    onValueModified: {
+                        if (root.train)
+                            root.train.set_wait(index, value)
+                    }
                 }
 
                 Button {
                     text: "\u2191"
                     enabled: index > 0
                     Layout.preferredWidth: 28
-                    onClicked: root.train.move_order(index, index - 1)
+                    onClicked: {
+                        if (root.train)
+                            root.train.move_order(index, index - 1)
+                    }
                 }
 
                 Button {
                     text: "\u2193"
-                    enabled: index < root.train.orders.count - 1
+                    enabled: root.train && index < root.train.orders.count - 1
                     Layout.preferredWidth: 28
-                    onClicked: root.train.move_order(index, index + 1)
+                    onClicked: {
+                        if (root.train)
+                            root.train.move_order(index, index + 1)
+                    }
                 }
 
                 Button {
                     text: "X"
                     Layout.preferredWidth: 28
-                    onClicked: root.train.remove_order(index)
+                    onClicked: {
+                        if (root.train)
+                            root.train.remove_order(index)
+                    }
                 }
             }
         }
@@ -137,7 +157,7 @@ Item {
             ComboBox {
                 id: markerPick
                 Layout.fillWidth: true
-                model: network.markerNodeIds
+                model: network ? network.markerNodeIds : []
                 enabled: count > 0
                 currentIndex: count > 0 ? 0 : -1
 
@@ -159,7 +179,9 @@ Item {
                         spacing: 6
 
                         Rectangle {
-                            property color nodeColor: network.color_for_node(modelData)
+                            property color nodeColor: network
+                                ? network.color_for_node(modelData)
+                                : "transparent"
                             visible: nodeColor.valid
                             color: nodeColor
                             border.width: 1
@@ -181,11 +203,13 @@ Item {
                     RowLayout {
                         anchors.fill: parent
                         anchors.leftMargin: 8
-                        anchors.rightMargin: markerPick.indicator.width + 8
+                        anchors.rightMargin: markerPick.indicator
+                            ? markerPick.indicator.width + 8
+                            : 8
                         spacing: 6
 
                         Rectangle {
-                            property color nodeColor: markerPick.currentIndex >= 0
+                            property color nodeColor: markerPick.currentIndex >= 0 && network
                                 ? network.color_for_node(markerPick.currentText)
                                 : "transparent"
                             visible: markerPick.currentIndex >= 0 && nodeColor.valid
@@ -207,19 +231,25 @@ Item {
 
             Button {
                 text: "Add"
-                enabled: markerPick.currentIndex >= 0 && markerPick.count > 0
-                onClicked: root.train.add_order(markerPick.currentText, 0)
+                enabled: root.train && markerPick.currentIndex >= 0 && markerPick.count > 0
+                onClicked: {
+                    if (root.train)
+                        root.train.add_order(markerPick.currentText, 0)
+                }
             }
 
             Button {
                 text: "Clear"
-                enabled: root.train.orders.count > 0
-                onClicked: root.train.clear_orders()
+                enabled: root.train && root.train.orders.count > 0
+                onClicked: {
+                    if (root.train)
+                        root.train.clear_orders()
+                }
             }
         }
 
         Text {
-            visible: network.markerNodeIds.length === 0
+            visible: !network || network.markerNodeIds.length === 0
             text: "Generate network to list markers"
             font.pixelSize: 11
             color: palette.mid

--- a/Controller/src/qml/RunPanel.qml
+++ b/Controller/src/qml/RunPanel.qml
@@ -9,9 +9,13 @@ Item {
         z: 1
 
         Button {
-            text: simulator.is_running ? "\u23F9 Stop Simulation" : "\u25B6 Simulate"
-            enabled: network.has_graph
-            onClicked: simulator.is_running ? simulator.stop() : simulator.start()
+            text: simulator && simulator.is_running ? "\u23F9 Stop Simulation" : "\u25B6 Simulate"
+            enabled: network && network.has_graph
+            onClicked: {
+                if (!simulator)
+                    return
+                simulator.is_running ? simulator.stop() : simulator.start()
+            }
         }
     }
 
@@ -20,8 +24,8 @@ Item {
 
         anchors.top: parent.top
         anchors.left: parent.left
-        height: trains.count > 0 ? Math.min(420, parent.height) : 0
-        width: trains.count > 0 ? Math.min(trains.count * 250, parent.width * 0.55) : 0
+        height: trains && trains.count > 0 ? Math.min(420, parent.height) : 0
+        width: trains && trains.count > 0 ? Math.min(trains.count * 250, parent.width * 0.55) : 0
 
         model: trains
         orientation: Qt.Horizontal
@@ -38,7 +42,7 @@ Item {
         Connections {
             target: trains
             function onCountChanged() {
-                if (trains.count === 0) {
+                if (!trains || trains.count === 0) {
                     Globals.planningTrainIndex = 0
                     return
                 }

--- a/Controller/src/qml/TrainControlPanel.qml
+++ b/Controller/src/qml/TrainControlPanel.qml
@@ -7,7 +7,7 @@ Item {
     id: root
 
     property Train train: model.object
-    property var device: root.train.device
+    property var device: root.train ? root.train.device : null
     property int trainIndex: 0
 
     readonly property bool isPlanningTarget: Globals.planningTrainIndex === trainIndex
@@ -39,8 +39,10 @@ Item {
         clip: true
 
         GroupBox {
-            title: root.device.name + (root.isPlanningTarget ? " (planning)" : "")
-            enabled: root.device.initialized
+            title: root.device
+                   ? root.device.name + (root.isPlanningTarget ? " (planning)" : "")
+                   : ""
+            enabled: root.device ? root.device.initialized : false
             width: root.width - 8
 
             ColumnLayout {
@@ -55,10 +57,10 @@ Item {
                 Slider {
                     id: speedSlider
 
-                    value: root.device.speed
+                    value: root.device ? root.device.speed : 0
                     orientation: Qt.Vertical
                     wheelEnabled: true
-                    from: root.device.minimalSpeed
+                    from: root.device ? root.device.minimalSpeed : 0
                     to: 100
                     stepSize: 10
                     snapMode: Slider.SnapAlways
@@ -70,6 +72,7 @@ Item {
                         target: root.device
                         property: "speed"
                         value: speedSlider.value
+                        when: root.device !== null
                     }
                 }
 
@@ -80,14 +83,16 @@ Item {
                 }
 
                 Text {
-                    text: "Voltage " + (root.device.voltage / 1000).toFixed(1) + " V"
+                    text: root.device
+                          ? "Voltage " + (root.device.voltage / 1000).toFixed(1) + " V"
+                          : "Voltage —"
                     Layout.alignment: Qt.AlignHCenter
                 }
 
                 Rectangle {
                     id: detectedColor
                     border.width: 2
-                    color: root.device.color
+                    color: root.device ? root.device.color : "transparent"
 
                     Layout.preferredHeight: 36
                     Layout.preferredWidth: 36
@@ -101,7 +106,9 @@ Item {
                 }
 
                 Text {
-                    text: root.train.current_segment_id || "unknown"
+                    text: root.train
+                          ? (root.train.current_segment_id || "unknown")
+                          : "unknown"
                     wrapMode: Text.WrapAnywhere
                     horizontalAlignment: Text.AlignHCenter
                     Layout.fillWidth: true
@@ -111,6 +118,7 @@ Item {
                     train: root.train
                     Layout.fillWidth: true
                     Layout.preferredHeight: implicitHeight
+                    visible: root.train !== null
                 }
             }
         }


### PR DESCRIPTION
## Summary
- Switch Qt Quick Controls to Fusion so ComboBox `contentItem` customization (marker color swatch) works on Windows without native-style warnings.
- Destroy the QML engine before `AppContext` on exit so context properties are not nulled while bindings still evaluate.
- Add null-safe bindings in Run/Train/Order/Devices/MultiPath panels to stop runtime and shutdown TypeErrors.

## Test plan
- [ ] Launch app, generate network, start simulator; confirm no `path_id` / ComboBox style warnings while running
- [ ] Open train order panel marker ComboBox; color swatch shows without style/customization warning
- [ ] Open Devices tab; switch rail labels still update with bindings
- [ ] Quit the app; console should not spam `is_running` / `bindingsRevision` / device property TypeErrors