### PR TITLE
A3.2: atomic whole-leg reserve/release

### DIFF
--- a/Controller/src/python/network_manager.py
+++ b/Controller/src/python/network_manager.py
@@ -90,6 +90,61 @@ class NetworkManager(QObject):
         for segment_id in [sid for sid, o in self._owners.items() if o == owner]:
             self.release_segment(segment_id, owner)
 
+    def try_reserve_leg(self, owner, segment_ids) -> bool:
+        """Atomically reserve every segment of a planned leg for owner.
+
+        Auto executor (B1) entry point: call before departure with
+        LegResult.segments. Returns True if all segments are free or already
+        owned by owner (then owns all). Returns False on conflict or unknown
+        segment id — ownership is unchanged (Hold). Empty leg succeeds.
+        """
+        if not owner:
+            return False
+        ids = list(segment_ids) if segment_ids else []
+        if not ids:
+            return True
+
+        for segment_id in ids:
+            if segment_id not in self._segments:
+                return False
+            current = self._owners.get(segment_id)
+            if current is not None and current != owner:
+                return False
+
+        newly_taken = []
+        for segment_id in ids:
+            if self._owners.get(segment_id) == owner:
+                continue
+            if not self.try_reserve_segment(segment_id, owner):
+                for taken in newly_taken:
+                    self.release_segment(taken, owner)
+                return False
+            newly_taken.append(segment_id)
+        return True
+
+    def release_leg(self, owner, segment_ids) -> bool:
+        """Release listed segments owned by owner (arrival / cancel cleanup).
+
+        Free segments are skipped. Segments owned by another party are left
+        alone and cause False, but this owner's segments in the list are still
+        released (best-effort). Empty list succeeds. Use release_all_for for
+        pause/manual full cleanup.
+        """
+        if not owner:
+            return False
+        ids = list(segment_ids) if segment_ids else []
+        ok = True
+        for segment_id in ids:
+            current = self._owners.get(segment_id)
+            if current is None:
+                continue
+            if current != owner:
+                ok = False
+                continue
+            if not self.release_segment(segment_id, owner):
+                ok = False
+        return ok
+
     def reserve_segments(self, segment_ids) -> bool:
         ok = True
         for segment_id in segment_ids or []:

--- a/Controller/tests/test_segment_ownership.py
+++ b/Controller/tests/test_segment_ownership.py
@@ -78,3 +78,56 @@ def test_generate_clears_owners(net_manager):
     assert net_manager.try_reserve_segment(SEGMENT_ID, "train-a")
     net_manager.generate()
     assert net_manager.owner_of(SEGMENT_ID) is None
+
+
+def _two_segments(net_manager):
+    segment_ids = list(net_manager.segments().keys())[:2]
+    assert len(segment_ids) == 2
+    return segment_ids
+
+
+def test_try_reserve_leg_blocks_other_owner(net_manager):
+    leg = _two_segments(net_manager)
+    assert net_manager.try_reserve_leg("train-a", leg)
+    assert all(net_manager.owner_of(sid) == "train-a" for sid in leg)
+
+    assert not net_manager.try_reserve_leg("train-b", leg)
+    assert all(net_manager.owner_of(sid) == "train-a" for sid in leg)
+
+
+def test_release_leg_then_other_owner_succeeds(net_manager):
+    leg = _two_segments(net_manager)
+    assert net_manager.try_reserve_leg("train-a", leg)
+    assert net_manager.release_leg("train-a", leg)
+    assert all(net_manager.owner_of(sid) is None for sid in leg)
+
+    assert net_manager.try_reserve_leg("train-b", leg)
+    assert all(net_manager.owner_of(sid) == "train-b" for sid in leg)
+
+
+def test_try_reserve_leg_partial_overlap_is_atomic(net_manager):
+    s1, s2 = _two_segments(net_manager)
+    assert net_manager.try_reserve_segment(s1, "train-a")
+
+    assert not net_manager.try_reserve_leg("train-b", [s1, s2])
+    assert net_manager.owner_of(s1) == "train-a"
+    assert net_manager.owner_of(s2) is None
+
+
+def test_try_reserve_leg_idempotent_for_same_owner(net_manager):
+    leg = _two_segments(net_manager)
+    assert net_manager.try_reserve_leg("train-a", leg)
+    assert net_manager.try_reserve_leg("train-a", leg)
+    assert all(net_manager.owner_of(sid) == "train-a" for sid in leg)
+
+
+def test_try_reserve_leg_empty_succeeds(net_manager):
+    assert net_manager.try_reserve_leg("train-a", [])
+    assert net_manager.try_reserve_leg("train-a", None)
+
+
+def test_try_reserve_leg_unknown_segment_fails_atomically(net_manager):
+    s1 = _two_segments(net_manager)[0]
+    assert not net_manager.try_reserve_leg("train-a", [s1, "XXX"])
+    assert net_manager.owner_of(s1) is None
+    assert net_manager.owner_of("XXX") is None


### PR DESCRIPTION
## Summary
- Add `try_reserve_leg` / `release_leg` on NetworkManager for all-or-nothing interlocking over a planned leg's segments
- Conflict or unknown segment leaves ownership unchanged (Hold-ready for B1 executor)
- Pytest coverage for conflict, release, partial overlap, idempotent re-reserve, empty leg, and unknown segment

Closes #136

## Test plan
- [x] `pytest tests/test_segment_ownership.py` (12 passed)
- [ ] Confirm existing sim occupancy flow still runs (A3.1 per-segment Train path unchanged)

Made with [Cursor](https://cursor.com)