### PR TITLE
C1.2: click canvas marker to add order

### DIFF
--- a/Controller/src/python/items/marker.py
+++ b/Controller/src/python/items/marker.py
@@ -150,6 +150,15 @@ class Marker(QObject):
     path_id_changed = Signal()
     path_id = Property(str, path_id, set_path_id, notify=path_id_changed)
 
+    def rail_id(self):
+        parent = self.parent()
+        rail = getattr(parent, "rail", None) if parent is not None else None
+        if rail is None:
+            return -1
+        return rail.id
+
+    rail_id = Property(int, rail_id, constant=True)
+
     def at_boundary(self):
         return self._connector != None
 

--- a/Controller/src/python/models/trains.py
+++ b/Controller/src/python/models/trains.py
@@ -1,7 +1,10 @@
 from __future__ import annotations
 
+from PySide6.QtCore import Property, Signal, Slot
+
 from python.models.object_based_model import ObjectBasedModel
 from python.items.train import Train
+
 
 class Trains(ObjectBasedModel[Train]):
 
@@ -11,6 +14,7 @@ class Trains(ObjectBasedModel[Train]):
         super().__init__(parent)
         self._network = network
         self._planner = planner
+        self._last_order_hint = ""
         train_devices.device_connected.connect(self.add_train)
 
     def add_train(self, device):
@@ -26,3 +30,35 @@ class Trains(ObjectBasedModel[Train]):
             return
 
         self.remove(train)
+
+    def last_order_hint(self):
+        return self._last_order_hint
+
+    last_order_hint_changed = Signal()
+    last_order_hint = Property(str, last_order_hint, notify=last_order_hint_changed)
+
+    def _set_last_order_hint(self, message: str):
+        print(f"Trains: {message}")
+        if self._last_order_hint == message:
+            return
+        self._last_order_hint = message
+        self.last_order_hint_changed.emit()
+
+    @Slot(int, int, str, int, result=bool)
+    def add_order_for_marker(self, train_index: int, rail_id: int, path_id: str, distance: int) -> bool:
+        train = self.get(train_index)
+        if train is None:
+            self._set_last_order_hint("No planning-target train")
+            return False
+
+        node_id = self._network.node_id_for_marker(rail_id, path_id, distance)
+        if not node_id:
+            if not self._network.has_graph:
+                self._set_last_order_hint("No graph")
+            else:
+                self._set_last_order_hint("Marker is not a graph node")
+            return False
+
+        train.add_order(node_id, 0.0)
+        self._set_last_order_hint(f"Added order {node_id}")
+        return True

--- a/Controller/src/python/network_manager.py
+++ b/Controller/src/python/network_manager.py
@@ -233,6 +233,21 @@ class NetworkManager(QObject):
             return QColor()
         return marker.color
 
+    @Slot(int, str, int, result=str)
+    def node_id_for_marker(self, rail_id: int, path_id: str, distance: int) -> str:
+        """Return the unique graph node id for a placed marker, or empty if unknown/ambiguous."""
+        node_ids = []
+        for entry in self._collect_graph_markers():
+            if entry["rail_id"] != rail_id or entry["distance"] != distance:
+                continue
+            if path_id not in (None, "", entry["path_id"]):
+                continue
+            if entry["node_id"] not in node_ids:
+                node_ids.append(entry["node_id"])
+        if len(node_ids) == 1:
+            return node_ids[0]
+        return ""
+
     def find_node_by_color(self, color_key: str):
         """color_key should be a lowercase hex string e.g. '#ff0000'"""
         return self._color_map.get(color_key)

--- a/Controller/src/qml/MarkerItem.qml
+++ b/Controller/src/qml/MarkerItem.qml
@@ -35,6 +35,26 @@ Item {
             visible: item.marker.taken
             color: item.marker.color
 
+            SequentialAnimation {
+                id: orderFlash
+                NumberAnimation { target: markerBrick; property: "opacity"; to: 0.4; duration: 80 }
+                NumberAnimation { target: markerBrick; property: "opacity"; to: 1.0; duration: 120 }
+            }
+
+            MouseArea {
+                enabled: !Globals.editMode && item.marker.taken
+                onClicked: {
+                    if (trains.add_order_for_marker(
+                            Globals.planningTrainIndex,
+                            item.marker.rail_id,
+                            item.marker.path_id,
+                            item.marker.distance)) {
+                        orderFlash.restart()
+                    }
+                }
+                anchors.fill: parent
+            }
+
             onVisibleChanged: { if (visible) {
                     selectableItem.forceActiveFocus()
                 } else {

--- a/Controller/src/qml/OrderListPanel.qml
+++ b/Controller/src/qml/OrderListPanel.qml
@@ -211,6 +211,15 @@ Item {
         }
 
         Text {
+            visible: trains && trains.last_order_hint.length > 0
+            text: trains ? trains.last_order_hint : ""
+            font.pixelSize: 11
+            color: palette.mid
+            Layout.fillWidth: true
+            wrapMode: Text.WordWrap
+        }
+
+        Text {
             visible: !network || network.markerNodeIds.length === 0
             text: "Generate network to list markers"
             font.pixelSize: 11

--- a/Controller/tests/test_marker_states.py
+++ b/Controller/tests/test_marker_states.py
@@ -134,3 +134,17 @@ def test_switch_path_id_filtering():
     # path B markers sharing nearby distances are unaffected
     assert marker(switch, 34, "B").state == MarkerState.Free
     assert marker(switch, 35, "B").state == MarkerState.Free
+
+
+def test_marker_rail_id():
+    rails = make_rails((RailType.Straight, 7))
+    rail = rails.findRailData(7)
+    taken = marker(rail, 8)
+    assert taken.rail_id == 7
+    assert all(m.rail_id == 7 for m in rail.markers._items)
+
+
+def test_marker_rail_id_without_parent():
+    from python.items.marker import Marker
+
+    assert Marker().rail_id == -1

--- a/Controller/tests/test_network_manager.py
+++ b/Controller/tests/test_network_manager.py
@@ -319,3 +319,30 @@ def test_marker_node_ids():
         "#00ff00": "1A10",
     }
     assert net_manager.marker_node_ids() == ["1A10", "2B20"]
+
+
+def test_node_id_for_marker():
+    data = project.loadDataFromFile(Path(TEST_TRACK))
+    rails = [Rail.load_data(d) for d in data.get("rails", [])]
+    mock_rails = MagicMock()
+    mock_rails.items.return_value = rails
+    net_manager = net.NetworkManager(mock_rails)
+
+    assert net_manager.node_id_for_marker(13, "A", 0) == ""
+
+    net_manager.generate()
+    red = next(entry for entry in net_manager._collect_graph_markers() if entry["color_key"] == "#ff0000")
+    assert net_manager.node_id_for_marker(red["rail_id"], red["path_id"], red["distance"]) == red["node_id"]
+    assert net_manager.node_id_for_marker(red["rail_id"], "", red["distance"]) == red["node_id"]
+    assert net_manager.node_id_for_marker(999, "A", 0) == ""
+
+
+def test_node_id_for_marker_ambiguous_switch_stem():
+    rails, switch = _make_switch_y_layout()
+    _force_take(switch, 1, "#ff0000")
+    net_manager = net.NetworkManager(rails)
+    net_manager.generate()
+
+    assert net_manager.node_id_for_marker(switch.id, "", 1) == ""
+    assert net_manager.node_id_for_marker(switch.id, "A", 1) == f"{switch.id}A1"
+    assert net_manager.node_id_for_marker(switch.id, "B", 1) == f"{switch.id}B1"

--- a/Controller/tests/test_train_orders.py
+++ b/Controller/tests/test_train_orders.py
@@ -1,9 +1,18 @@
 from unittest.mock import MagicMock
 
+import pytest
 from PySide6.QtGui import QColor
+from PySide6.QtWidgets import QApplication
 
 from python.items.train_device_sim import TrainDeviceSim
 from python.items.train import Train, ControlMode
+from python.models.trains import Trains
+
+
+@pytest.fixture(scope="session", autouse=True)
+def ensure_qapp():
+    app = QApplication.instance() or QApplication([])
+    yield app
 
 
 def _make_train():
@@ -79,3 +88,56 @@ def test_localization_unchanged_with_orders():
     network.find_node_by_color.assert_called()
     assert train.orders.count == 1
     assert train.current_node_id == ""
+
+
+def _make_trains(network=None):
+    if network is None:
+        network = MagicMock()
+        network.has_graph = True
+        network.node_id_for_marker.return_value = "13A0"
+    devices = MagicMock()
+    return Trains(network, devices), network
+
+
+def test_add_order_for_marker():
+    trains, network = _make_trains()
+    trains.add_train(TrainDeviceSim(name="sim"))
+
+    assert trains.add_order_for_marker(0, 13, "A", 0) is True
+    network.node_id_for_marker.assert_called_with(13, "A", 0)
+    train = trains.get(0)
+    assert train.orders.count == 1
+    assert train.orders.get(0).target_node_id == "13A0"
+    assert train.orders.get(0).wait_seconds == 0.0
+    assert trains.last_order_hint == "Added order 13A0"
+
+
+def test_add_order_for_marker_no_train():
+    trains, _ = _make_trains()
+
+    assert trains.add_order_for_marker(0, 13, "A", 0) is False
+    assert trains.last_order_hint == "No planning-target train"
+
+
+def test_add_order_for_marker_no_graph():
+    network = MagicMock()
+    network.has_graph = False
+    network.node_id_for_marker.return_value = ""
+    trains, _ = _make_trains(network)
+    trains.add_train(TrainDeviceSim(name="sim"))
+
+    assert trains.add_order_for_marker(0, 13, "A", 0) is False
+    assert trains.get(0).orders.count == 0
+    assert trains.last_order_hint == "No graph"
+
+
+def test_add_order_for_marker_unknown_node():
+    network = MagicMock()
+    network.has_graph = True
+    network.node_id_for_marker.return_value = ""
+    trains, _ = _make_trains(network)
+    trains.add_train(TrainDeviceSim(name="sim"))
+
+    assert trains.add_order_for_marker(0, 13, "A", 0) is False
+    assert trains.get(0).orders.count == 0
+    assert trains.last_order_hint == "Marker is not a graph node"


### PR DESCRIPTION
## Summary
- In Run mode, clicking a placed marker appends it as an order on the planning-target train
- Node ids are resolved in Python (`NetworkManager.node_id_for_marker` / `Trains.add_order_for_marker`); Edit-mode marker placement and selection are unchanged
- Failed clicks (no train, no graph, unknown/ambiguous node) are ignored and shown via `last_order_hint`

## Test plan
- [ ] Generate network, select a train, click a colored marker in Run mode — order appears with the correct node id
- [ ] Click with no trains / before Generate — no order added, status hint shown
- [ ] Edit mode: placing, selecting, and deleting markers still works
- [ ] Auto executor can consume canvas-clicked orders without typing node ids

Closes #141