### PR TITLE
B1.3: Auto routing — forward loop, allow reverse, cruise speed

### DIFF
--- a/Controller/src/python/items/train.py
+++ b/Controller/src/python/items/train.py
@@ -36,6 +36,7 @@ class Train(QObject):
         self._orders = Orders(parent=self)
         self._current_order_index = 0
         self._control_mode = ControlMode.Manual
+        self._allow_reverse = False
         self._executor = PlanExecutor(self, planner, network, parent=self) if planner is not None else None
 
         device.color_changed.connect(self.on_color_changed)
@@ -177,6 +178,18 @@ class Train(QObject):
 
     control_mode_changed = Signal()
     control_mode = Property(int, control_mode, set_control_mode, notify=control_mode_changed)
+
+    def allow_reverse(self):
+        return self._allow_reverse
+
+    def set_allow_reverse(self, value):
+        value = bool(value)
+        if self._allow_reverse != value:
+            self._allow_reverse = value
+            self.allow_reverse_changed.emit()
+
+    allow_reverse_changed = Signal()
+    allow_reverse = Property(bool, allow_reverse, set_allow_reverse, notify=allow_reverse_changed)
 
     def executor(self):
         return self._executor

--- a/Controller/src/python/items/train_device_sim.py
+++ b/Controller/src/python/items/train_device_sim.py
@@ -13,4 +13,4 @@ class TrainDeviceSim(TrainDevice):
     """Simulated train hub with no BLE connection."""
 
     def __init__(self, name="Simulator", parent=None):
-        super().__init__(name=name, initialized=True, minimal_speed=0, parent=parent)
+        super().__init__(name=name, initialized=True, minimal_speed=-100, parent=parent)

--- a/Controller/src/python/plan_executor.py
+++ b/Controller/src/python/plan_executor.py
@@ -184,10 +184,19 @@ class PlanExecutor(QObject):
             self._set_state(ExecutorState.WAITING_FOR_LOCALIZATION)
             return
 
-        leg = self._planner.compute_leg(current, order.target_node_id)
+        previous = self._previous_node_id or None
+        exclude = previous if previous and not self._network.is_dead_end(current) else None
+
+        leg = self._planner.compute_leg(current, order.target_node_id, exclude_neighbor=exclude)
         if leg is None:
-            self._hold("no path")
-            return
+            unrestricted = self._planner.compute_leg(current, order.target_node_id)
+            if unrestricted is None:
+                self._hold("no path")
+                return
+            if not self._train.allow_reverse:
+                self._hold("no reverse")
+                return
+            leg = unrestricted
 
         if len(leg.nodes) <= 1 or not leg.segments:
             if self._state == ExecutorState.WAITING:
@@ -197,8 +206,8 @@ class PlanExecutor(QObject):
             return
 
         first_hop = leg.nodes[1]
-        previous = self._previous_node_id or None
-        if self._network.is_reverse_depart(current, previous, first_hop):
+        reversing = self._network.is_reverse_depart(current, previous, first_hop)
+        if reversing and not self._train.allow_reverse:
             self._hold("no reverse")
             return
 
@@ -208,7 +217,7 @@ class PlanExecutor(QObject):
 
         self._current_leg = leg
         self._cancel_task()
-        flip = bool(previous) and self._network.is_dead_end(current)
+        flip = reversing or (bool(previous) and self._network.is_dead_end(current))
         self._apply_moving_speed(flip=flip)
         self._train.set_current_segment_ids(leg.segments, f"{leg.nodes[0]}:{leg.nodes[-1]}")
         self._set_state(ExecutorState.MOVING)

--- a/Controller/src/python/plan_executor.py
+++ b/Controller/src/python/plan_executor.py
@@ -185,7 +185,9 @@ class PlanExecutor(QObject):
             return
 
         previous = self._previous_node_id or None
-        exclude = previous if previous and not self._network.is_dead_end(current) else None
+        exclude = None
+        if previous and not self._network.is_dead_end(current) and not self._train.allow_reverse:
+            exclude = previous
 
         leg = self._planner.compute_leg(current, order.target_node_id, exclude_neighbor=exclude)
         if leg is None:

--- a/Controller/src/python/plan_executor.py
+++ b/Controller/src/python/plan_executor.py
@@ -37,6 +37,7 @@ class PlanExecutor(QObject):
         self._current_leg = None
         self._cruise_speed = 0
         self._task = None
+        self._train.device.speed_changed.connect(self._capture_cruise)
 
     def status(self):
         if self._state == ExecutorState.HOLD and self._hold_reason:
@@ -155,13 +156,13 @@ class PlanExecutor(QObject):
         self.try_depart()
 
     def _arrive(self, order):
-        self._set_speed(0)
-        self._release_current_leg()
-        self._set_state(ExecutorState.WAITING)
         wait = float(order.wait_seconds) if order is not None else 0.0
+        self._release_current_leg()
         if wait <= 0:
             self._advance_and_depart()
             return
+        self._set_speed(0)
+        self._set_state(ExecutorState.WAITING)
         self._schedule_wait(wait)
 
     @Slot()

--- a/Controller/src/python/planner.py
+++ b/Controller/src/python/planner.py
@@ -61,25 +61,37 @@ class Planner(QObject):
     def updateRailsModel(self, rails):
         self._rails = rails
 
-    def compute_leg(self, from_node: str, to_node: str) -> LegResult | None:
+    def compute_leg(self, from_node: str, to_node: str, exclude_neighbor: str | None = None) -> LegResult | None:
         """Shortest path between two marker (or graph) nodes.
 
         Uses undirected edge weights. Switch position is not applied during search —
         either branch may appear. required_switches lists SwitchLeft/SwitchRight
         path_ids from the chosen path's segment_data (not live rail.switch_position).
 
-        Same-node (when the node exists): trivial leg with that node, empty
-        segments, length 0, and no required switches. Unknown nodes, missing
-        graph, no path, or conflicting switch path_ids on one leg: None.
+        If exclude_neighbor is set, the arrival edge from that neighbor (or the
+        graph neighbor used to enter from_node) is removed on a copy so search
+        continues forward. Same-node (when the node exists): trivial leg with that
+        node, empty segments, length 0, and no required switches. Unknown nodes,
+        missing graph, no path, or conflicting switch path_ids on one leg: None.
         """
         graph = self._network.graph()
         if graph is None or from_node not in graph or to_node not in graph:
             return None
         if from_node == to_node:
             return LegResult(nodes=[from_node], segments=[], length=0.0, required_switches=())
+
+        search = graph
+        if exclude_neighbor:
+            blocked = exclude_neighbor
+            if not graph.has_edge(from_node, blocked):
+                blocked = self._network._resolve_exclude_neighbor(from_node, exclude_neighbor)
+            if blocked and graph.has_edge(from_node, blocked):
+                search = graph.copy()
+                search.remove_edge(from_node, blocked)
+
         try:
-            nodes = nx.shortest_path(graph, from_node, to_node, weight="weight")
-            length = nx.shortest_path_length(graph, from_node, to_node, weight="weight")
+            nodes = nx.shortest_path(search, from_node, to_node, weight="weight")
+            length = nx.shortest_path_length(search, from_node, to_node, weight="weight")
         except nx.NetworkXNoPath:
             return None
         segments = [

--- a/Controller/src/python/simulator.py
+++ b/Controller/src/python/simulator.py
@@ -43,6 +43,13 @@ class Simulator(QObject):
 
     def _advance_to_next_marker(self) -> bool:
         """Move current/previous to the next switch-aware marker. Returns False if stuck."""
+        going_reverse = self._sim_device is not None and self._sim_device.speed < 0
+        if going_reverse and self._previous_node_id:
+            next_node = self._previous_node_id
+            self._previous_node_id = self._current_node_id
+            self._current_node_id = next_node
+            return True
+
         next_node = self._network.find_next_marker_node(self._current_node_id, self._previous_node_id)
 
         if next_node is None:
@@ -72,7 +79,7 @@ class Simulator(QObject):
         # 25 = 1.6
         # 50 = 0.8
         # 100 = 0.4
-        self._step_delay = 40 / self._sim_device.speed
+        self._step_delay = 40 / abs(self._sim_device.speed)
         print("speed changed", self._sim_device.speed, "simulation speed", self._step_delay)
 
     def _cancel_run_task(self):

--- a/Controller/src/qml/OrderListPanel.qml
+++ b/Controller/src/qml/OrderListPanel.qml
@@ -52,7 +52,7 @@ Item {
                     root.train.allow_reverse = checked
             }
             ToolTip.visible: hovered
-            ToolTip.text: "When Auto cannot continue forward, reverse instead of Hold"
+            ToolTip.text: "Use the shortest path even if that means reversing"
             Layout.fillWidth: true
         }
 

--- a/Controller/src/qml/OrderListPanel.qml
+++ b/Controller/src/qml/OrderListPanel.qml
@@ -44,6 +44,18 @@ Item {
             }
         }
 
+        CheckBox {
+            text: "Allow reverse"
+            checked: root.train && root.train.allow_reverse
+            onToggled: {
+                if (root.train)
+                    root.train.allow_reverse = checked
+            }
+            ToolTip.visible: hovered
+            ToolTip.text: "When Auto cannot continue forward, reverse instead of Hold"
+            Layout.fillWidth: true
+        }
+
         Text {
             visible: root.train && root.train.control_mode === Train.Automatic
             text: root.train && root.train.executor ? root.train.executor.status : ""

--- a/Controller/tests/test_plan_executor.py
+++ b/Controller/tests/test_plan_executor.py
@@ -233,6 +233,55 @@ def test_fallback_speed_when_last_speed_is_zero():
     assert device.speed == FALLBACK_SPEED
 
 
+def test_live_speed_survives_wait0_arrive():
+    planner, network, _switch = _planner_from_switch_y_with_markers()
+    start = network.find_node_by_color("#ff0000")
+    dest = network.find_node_by_color("#00ff00")
+    assert start and dest
+
+    train, device = _auto_train(planner, network)
+    device.set_speed(40)
+    train.set_current_node_id(start)
+    train.add_order(dest, 0.0)
+    train.add_order(start, 0.0)
+    train.set_control_mode(ControlMode.Automatic)
+
+    assert train.executor.status == ExecutorState.MOVING
+    assert abs(device.speed) == 40
+
+    device.set_speed(80 if device.speed > 0 else -80)
+    device.set_color(QColor("#00ff00"))
+    assert train.current_node_id == dest
+    assert train.executor.status == ExecutorState.MOVING
+    assert abs(device.speed) == 80
+
+
+def test_positive_wait_stops_then_departs():
+    planner, network, _switch = _planner_from_switch_y_with_markers()
+    start = network.find_node_by_color("#ff0000")
+    dest = network.find_node_by_color("#00ff00")
+    assert start and dest
+
+    train, device = _auto_train(planner, network)
+    train.executor._hold_retry_s = 0.02
+    device.set_speed(40)
+    train.set_current_node_id(start)
+    train.add_order(dest, 0.05)
+    train.add_order(start, 0.0)
+
+    async def scenario():
+        train.set_control_mode(ControlMode.Automatic)
+        assert train.executor.status == ExecutorState.MOVING
+        device.set_color(QColor("#00ff00"))
+        assert train.executor.status == ExecutorState.WAITING
+        assert device.speed == 0
+        await asyncio.sleep(0.08)
+        assert train.executor.status == ExecutorState.MOVING
+        assert abs(device.speed) == 40
+
+    asyncio.run(scenario())
+
+
 def test_pause_releases_leg_and_keeps_orders():
     planner, network = _planner_from_track(TEST_TRACK)
     yellow = network.find_node_by_color(YELLOW)

--- a/Controller/tests/test_plan_executor.py
+++ b/Controller/tests/test_plan_executor.py
@@ -165,24 +165,85 @@ def test_hold_retry_moves_when_leg_frees():
     asyncio.run(scenario())
 
 
+def _planner_from_linear_three_markers():
+    """Three connected straights — middle marker has two neighbors, no loop."""
+    rails = Rails(ConnectorRegister())
+    rails._items = [
+        Rail(type=RailType.Straight, id=1, parent=rails),
+        Rail(type=RailType.Straight, id=2, parent=rails),
+        Rail(type=RailType.Straight, id=3, parent=rails),
+    ]
+    a, b, c = rails._items
+    a.connectTo(b.id, 1)
+    b.connectTo(a.id, 0)
+    b.connectTo(c.id, 1)
+    c.connectTo(b.id, 0)
+    _force_take(a, 8, "#ff0000")
+    _force_take(b, 8, "#00ff00")
+    _force_take(c, 8, "#0000ff")
+    network = net.NetworkManager(rails)
+    network.generate()
+    return Planner(rails, network), network
+
+
 def test_non_dead_end_reverse_holds():
-    planner, network = _planner_from_track(TEST_TRACK)
-    yellow = network.find_node_by_color(YELLOW)
-    red = network.find_node_by_color(RED)
-    leg = planner.compute_leg(red, yellow)
-    assert leg is not None
-    assert network.graph().degree(red) > 1
-    assert network.is_reverse_depart(red, yellow, leg.nodes[1])
+    planner, network = _planner_from_linear_three_markers()
+    red = network.find_node_by_color("#ff0000")
+    green = network.find_node_by_color("#00ff00")
+    assert red and green
+    assert network.graph().degree(green) > 1
 
     train, device = _auto_train(planner, network)
-    train.set_current_node_id(red)
-    train.executor.set_previous_node_id(yellow)
-    train.add_order(yellow, 0.0)
+    train.set_current_node_id(green)
+    train.executor.set_previous_node_id(red)
+    train.add_order(red, 0.0)
     train.set_control_mode(ControlMode.Automatic)
 
     assert train.executor.status == "Hold: no reverse"
     assert device.speed == 0
-    assert network.owner_of(leg.segments[0]) is None
+
+
+def test_allow_reverse_departs_when_no_forward_path():
+    planner, network = _planner_from_linear_three_markers()
+    red = network.find_node_by_color("#ff0000")
+    green = network.find_node_by_color("#00ff00")
+
+    train, device = _auto_train(planner, network)
+    device.set_speed(40)
+    train.set_allow_reverse(True)
+    train.set_current_node_id(green)
+    train.executor.set_previous_node_id(red)
+    train.add_order(red, 0.0)
+    train.set_control_mode(ControlMode.Automatic)
+
+    assert train.executor.status == ExecutorState.MOVING
+    assert device.speed == -40
+
+
+def test_oval_two_stops_loop_forward_without_reverse():
+    planner, network = _planner_from_track(TEST_TRACK)
+    blue = network.find_node_by_color("#0000ff")
+    red = network.find_node_by_color(RED)
+    assert blue == "10A0"
+    assert red == "13A0"
+
+    train, device = _auto_train(planner, network)
+    device.set_speed(40)
+    train.set_current_node_id(blue)
+    train.add_order(red, 0.0)
+    train.add_order(blue, 0.0)
+    train.set_control_mode(ControlMode.Automatic)
+
+    assert train.executor.status == ExecutorState.MOVING
+    assert device.speed > 0
+
+    device.set_color(QColor(RED))
+    assert train.current_node_id == red
+    assert train.executor.status == ExecutorState.MOVING
+    assert device.speed != 0
+    assert train.executor.status != "Hold: no reverse"
+    forward = planner.compute_leg(red, blue, exclude_neighbor=blue)
+    assert all(network.owner_of(sid) == device.name for sid in forward.segments)
 
 
 def test_dead_end_reverse_allowed_flips_signed_speed():

--- a/Controller/tests/test_plan_executor.py
+++ b/Controller/tests/test_plan_executor.py
@@ -246,6 +246,29 @@ def test_oval_two_stops_loop_forward_without_reverse():
     assert all(network.owner_of(sid) == device.name for sid in forward.segments)
 
 
+def test_allow_reverse_uses_shortest_path_even_if_reverse():
+    planner, network = _planner_from_track(TEST_TRACK)
+    blue = network.find_node_by_color("#0000ff")
+    red = network.find_node_by_color(RED)
+    assert blue == "10A0"
+    assert red == "13A0"
+
+    train, device = _auto_train(planner, network)
+    device.set_speed(40)
+    train.set_allow_reverse(True)
+    train.set_current_node_id(red)
+    train.executor.set_previous_node_id(blue)
+    train.add_order(blue, 0.0)
+    train.set_control_mode(ControlMode.Automatic)
+
+    assert train.executor.status == ExecutorState.MOVING
+    assert device.speed == -40
+    short = planner.compute_leg(red, blue)
+    assert short.nodes[1] == blue
+    assert train.current_segment_id == f"{red}:{blue}"
+    assert all(network.owner_of(sid) == device.name for sid in short.segments)
+
+
 def test_dead_end_reverse_allowed_flips_signed_speed():
     planner, network, _switch = _planner_from_switch_y_with_markers()
     approach = network.find_node_by_color("#ff0000")

--- a/Controller/tests/test_planner.py
+++ b/Controller/tests/test_planner.py
@@ -166,3 +166,17 @@ def test_collect_required_switches_conflict_returns_none():
     )
 
     assert collect_required_switches(rails, graph, ["n0", "n1", "n2"]) is None
+
+
+def test_compute_leg_exclude_neighbor_takes_long_way_on_oval():
+    planner, network = _planner_from_track(TEST_TRACK)
+    reverse = planner.compute_leg("13A0", "10A0")
+    assert reverse is not None
+    assert reverse.nodes[1] == "10A0"
+
+    forward = planner.compute_leg("13A0", "10A0", exclude_neighbor="10A0")
+    assert forward is not None
+    assert forward.nodes[0] == "13A0"
+    assert forward.nodes[-1] == "10A0"
+    assert forward.nodes[1] != "10A0"
+    assert len(forward.segments) > len(reverse.segments)

--- a/Controller/tests/test_simulator_pause.py
+++ b/Controller/tests/test_simulator_pause.py
@@ -78,3 +78,25 @@ def test_unpause_does_not_start_second_loop_while_running():
     ensure_future.assert_not_called()
     assert sim._run_task is first
     assert sim._current_node_id == "nodeA"
+
+
+def test_negative_speed_advances_to_previous_marker():
+    network = MagicMock()
+    sim = Simulator(network, MagicMock())
+    sim._current_node_id = "nodeB"
+    sim._previous_node_id = "nodeA"
+    sim._sim_device = TrainDeviceSim()
+    sim._sim_device.set_speed(-40)
+
+    assert sim._advance_to_next_marker() is True
+    assert sim._current_node_id == "nodeA"
+    assert sim._previous_node_id == "nodeB"
+    network.find_next_marker_node.assert_not_called()
+
+
+def test_step_delay_uses_abs_speed():
+    sim = Simulator(MagicMock(), MagicMock())
+    sim._sim_device = TrainDeviceSim()
+    sim._sim_device.set_speed(-50)
+    sim.onSpeedChanged()
+    assert sim._step_delay == 40 / 50

--- a/Controller/tests/test_train_device.py
+++ b/Controller/tests/test_train_device.py
@@ -21,7 +21,7 @@ def test_train_device_sim_exposes_shared_property_names():
     assert isinstance(device, TrainDevice)
     assert device.name == "sim"
     assert device.initialized is True
-    assert device.minimalSpeed == 0
+    assert device.minimalSpeed == -100
 
 
 def test_train_accepts_train_device_sim():

--- a/docs/route-planning-task-prompts.md
+++ b/docs/route-planning-task-prompts.md
@@ -41,7 +41,7 @@ Editor multi-color chip and other UX/UI polish: see GitHub epic **[#158](https:/
 5. A2.3 (**S**, A2.1) anytime after A2.1
 
 ### Phase 2 — One Auto train (sim)
-6. S1 (**M–L**, A1) → B1.1 (**S–M**) → B1.2 (**L**, A2+A3+B1.1) → S2 (**L**, S1+B1.2)  
+6. S1 (**M–L**, A1) → B1.1 (**S–M**) → B1.2 (**L**, A2+A3+B1.1) → **B1.3** #187 (**M**, B1.2) → S2 (**L**, S1+B1.2)  
 7. B2 (**M**, B1.2) later
 
 ### Phase 3 — Switches + plan UI
@@ -81,7 +81,7 @@ These decisions are final for MVP:
 | Switch modes | Per-switch **Manual** \| **Automatic** (logical first) |
 | Physical switches | Later; same style BLE hub as trains — not in early slices |
 | Auto speed | Reuse last non-zero speed; fallback constant (e.g. 40) |
-| Auto travel direction | Prefer continue **forward** along arrival direction (same `exclude_node` idea as NetworkManager). Reverse only at **dead-ends** (sole neighbor). Executor sets signed speed (`fwd`/`rev`) to match the reserved leg’s first hop. Mid-leg reverse forbidden. |
+| Auto travel direction | Prefer continue **forward** along arrival direction (same `exclude_node` idea as NetworkManager). Reverse only at **dead-ends** (sole neighbor), unless **Allow reverse** is on (B1.3): then use Dijkstra’s true shortest path, including reverse, and flip signed speed. Executor sets signed speed (`fwd`/`rev`) to match the reserved leg’s first hop. Mid-leg reverse forbidden. |
 | Manual during plan | **Pause** executor; keep orders; release current leg reservation |
 | Persist orders | Session-only in MVP |
 | First verification | Simulator first, then real hub |
@@ -634,6 +634,41 @@ Canvas order editing UI (C1), switch click UI (C2), physical hubs, order persist
 Changing compute_leg graph search / A2.2 required_switches (planner stays undirected; orientation is executor-side at depart time).
 ```
 
+### Subtask B1.3 — Auto routing: forward loop, allow reverse, cruise speed (#187)
+
+GitHub: https://github.com/arxarian/lego-trains-controller/issues/187
+
+**P0.** Follow-up to B1.2 so a looping oval plan behaves well.
+
+**Prompt:**
+
+```
+Harden Auto so a looping oval plan behaves well: keep cruise speed, prefer the long forward way when reverse is off, and take Dijkstra’s true shortest path (including reverse) when Allow reverse is on.
+
+## Depends on
+B1.2 (done). C1.2 not required.
+
+## Why
+B1.2 Hold-on-reverse made two nearby oval stops reverse or Hold. Wait-0 arrive also froze cruise speed. Sim could not walk a reverse hop.
+
+## Requirements
+1. Cruise: PlanExecutor listens to device.speed_changed; wait 0 does not zero speed.
+2. allow_reverse off (default): compute_leg(..., exclude_neighbor=previous) unless dead-end; Hold if only reverse exists.
+3. allow_reverse on: no exclude; if first hop is reverse, stay Moving and flip signed speed.
+4. Per-train Allow reverse checkbox on OrderListPanel; tooltip: “Use the shortest path even if that means reversing.”
+5. Sim: negative speed walks the previous marker (minimal_speed -100).
+
+## Acceptance
+- Oval 10A0→13A0→10A0, reverse off: long forward way, not Hold.
+- Same layout, reverse on, at 13A0 previous 10A0, next 10A0: first hop 10A0, speed negative, Moving.
+- Dead-end reverse still allowed with the checkbox off.
+- Slider change while Auto updates cruise; wait 0 does not stop.
+- pytest in test_plan_executor.py / test_planner.py / sim tests.
+
+## Out of scope
+Canvas click-to-order (C1.2). Physical switch throwing (C2.2). Persist allow_reverse (E1).
+```
+
 ---
 
 ## Issue B2 — Train Manual / Automatic mode
@@ -1068,6 +1103,7 @@ Design-only or later implementation: allow meets at sidings; reserve only to nex
 | A3.2 | feat(network): atomic leg reserve/release |
 | B1.1 | feat(train): Tycoon-style order list model |
 | B1.2 | feat(train): plan executor with hold + looping orders |
+| B1.3 | feat(train): Auto routing — forward loop, allow reverse, cruise speed (#187) |
 | B2 | feat(train): Manual vs Automatic control mode |
 | C1.1 | feat(ui): order list panel in Run mode |
 | C1.2 | feat(ui): click canvas marker to add order |


### PR DESCRIPTION
## Summary
- Keep Auto cruise speed in sync with the slider (wait 0 no longer zeros speed)
- Default Auto still goes the long forward way around an oval; Hold if only reverse exists
- **Allow reverse** takes Dijkstra’s true shortest path, including a reverse hop with flipped signed speed
- Simulator walks the previous marker when speed is negative

## Test plan
- [ ] Oval two nearby stops, Allow reverse off: long forward reservation, not Hold
- [ ] Same layout, Allow reverse on: short reverse hop, negative speed, Moving
- [ ] Dead-end reverse still works with the checkbox off
- [ ] Change the speed slider while Auto is running; wait-0 stops keep moving
- [ ] pytest: `tests/test_plan_executor.py`, `tests/test_planner.py`, sim reverse tests

Closes #187
