### PR TITLE
docs: mark C1.2 and B1.3 done in the task order

### DIFF
--- a/docs/route-planning-task-prompts.md
+++ b/docs/route-planning-task-prompts.md
@@ -43,12 +43,12 @@ Editor multi-color chip and other UX/UI polish: see GitHub epic **[#158](https:/
 5. A2.3 (**S**, A2.1) anytime after A2.1
 
 ### Phase 2 — One Auto train (sim)
-6. S1 (**M–L**, A1) → B1.1 (**S–M**) → B1.2 (**L**, A2+A3+B1.1) → **B1.3** #187 (**M**, B1.2) → S2 (**L**, S1+B1.2)  
+6. S1 (**M–L**, A1) → B1.1 (**S–M**) → B1.2 (**L**, A2+A3+B1.1) → **B1.3** #187 (**M**, B1.2, done) → S2 (**L**, S1+B1.2)  
 7. B2 (**M**, B1.2) later; **B2.1** #185 (**S–M**, B1.2) Stop/Resume toggle (P1)
 
 ### Phase 3 — Switches + plan UI
 8. SW1 (**L**, A1.1; F3 for HW role routing) → C2.1 (**S–M**, A1.1) → C2.2 (**M–L**)  
-9. C1.1 (**M**, B1.1) → **E1** #184 (**M**, C1.1) persist stops/waits (P0 for testing) → C1.2 (**M**, C1.1)  
+9. C1.1 (**M**, B1.1) → **E1** #184 (**M**, C1.1) persist stops/waits (P0 for testing) → C1.2 (**M**, C1.1, done)  
    C1.3 #186 (**S**, C1.1) wider panel + stop list fills space (P2 layout)  
 10. SW2 (**L**, SW1) when hardware ready; pairs with F3 switch role on hub  
 11. SW3 (**L**, SW2) one hub → up to four turnouts (multi-channel)


### PR DESCRIPTION
## Summary
- Mark C1.2 (#141 / #182) and B1.3 (#187 / #188) as done in the recommended implementation order
- GitHub epics #155 and #158 already list both tasks in Done

## Test plan
- [ ] Skim #155 Done table for C1.2 and B1.3
- [ ] Confirm easy starters no longer list C1.2
