### PR TITLE
B2.1: Stop button pause/resume with previous speed

### DIFF
--- a/Controller/TrainsController.pyproject
+++ b/Controller/TrainsController.pyproject
@@ -12,6 +12,7 @@
         "tests/test_train_device.py",
         "tests/test_train_orders.py",
         "tests/test_plan_executor.py",
+        "tests/test_stop_toggle.py",
         "tests/test_switch_position.py",
         "tests/test_switch_device.py",
         "tests/test_switch_device_hw.py",

--- a/Controller/src/python/items/train.py
+++ b/Controller/src/python/items/train.py
@@ -37,9 +37,12 @@ class Train(QObject):
         self._current_order_index = 0
         self._control_mode = ControlMode.Manual
         self._allow_reverse = False
+        self._halted_by_stop = False
+        self._resume_speed = 0
         self._executor = PlanExecutor(self, planner, network, parent=self) if planner is not None else None
 
         device.color_changed.connect(self.on_color_changed)
+        device.speed_changed.connect(self._on_speed_changed)
 
     def on_color_changed(self):
         color = self._device.color
@@ -170,6 +173,7 @@ class Train(QObject):
         if self._control_mode != value:
             self._control_mode = value
             self.control_mode_changed.emit()
+            self.set_halted_by_stop(False)
             if self._executor is not None:
                 if value == ControlMode.Automatic:
                     self._executor.resume()
@@ -191,10 +195,52 @@ class Train(QObject):
     allow_reverse_changed = Signal()
     allow_reverse = Property(bool, allow_reverse, set_allow_reverse, notify=allow_reverse_changed)
 
+    def halted_by_stop(self):
+        return self._halted_by_stop
+
+    def set_halted_by_stop(self, value):
+        value = bool(value)
+        if self._halted_by_stop != value:
+            self._halted_by_stop = value
+            self.halted_by_stop_changed.emit()
+
+    halted_by_stop_changed = Signal()
+    halted_by_stop = Property(bool, halted_by_stop, set_halted_by_stop, notify=halted_by_stop_changed)
+
     def executor(self):
         return self._executor
 
     executor = Property(QObject, executor, constant=True)
+
+    def _on_speed_changed(self):
+        speed = self._device.speed
+        if speed == 0:
+            return
+        self._resume_speed = speed
+        if self._halted_by_stop and self._control_mode == ControlMode.Manual:
+            self.set_halted_by_stop(False)
+
+    def _halt_by_stop(self):
+        if self._device.speed != 0:
+            self._resume_speed = self._device.speed
+        if self._control_mode == ControlMode.Automatic and self._executor is not None:
+            self._executor.pause()
+        self._device.set_speed(0)
+        self.set_halted_by_stop(True)
+
+    def _resume_from_stop(self):
+        self.set_halted_by_stop(False)
+        if self._control_mode == ControlMode.Automatic and self._executor is not None:
+            self._executor.resume()
+            return
+        self._device.set_speed(self._resume_speed)
+
+    @Slot()
+    def toggle_stop(self):
+        if self._halted_by_stop:
+            self._resume_from_stop()
+        else:
+            self._halt_by_stop()
 
     def _clamp_current_order_index(self):
         count = self._orders.rowCount()

--- a/Controller/src/python/plan_executor.py
+++ b/Controller/src/python/plan_executor.py
@@ -36,6 +36,7 @@ class PlanExecutor(QObject):
         self._previous_node_id = ""
         self._current_leg = None
         self._cruise_speed = 0
+        self._paused_while_waiting = False
         self._task = None
         self._train.device.speed_changed.connect(self._capture_cruise)
 
@@ -250,6 +251,7 @@ class PlanExecutor(QObject):
 
     @Slot()
     def pause(self):
+        self._paused_while_waiting = self._state == ExecutorState.WAITING
         self._cancel_task()
         self._release_current_leg()
         if self._network is not None:
@@ -264,8 +266,14 @@ class PlanExecutor(QObject):
         self._current_leg = None
         self._capture_cruise()
         if not self._train.current_node_id:
+            self._paused_while_waiting = False
             self._set_speed(0)
             self._set_state(ExecutorState.WAITING_FOR_LOCALIZATION)
+            return
+        if self._paused_while_waiting:
+            self._paused_while_waiting = False
+            self._set_state(ExecutorState.IDLE)
+            self._advance_and_depart()
             return
         self._set_state(ExecutorState.IDLE)
         self.try_depart()

--- a/Controller/src/qml/TrainControlPanel.qml
+++ b/Controller/src/qml/TrainControlPanel.qml
@@ -64,6 +64,7 @@ Item {
                     to: 100
                     stepSize: 10
                     snapMode: Slider.SnapAlways
+                    enabled: root.train && root.train.control_mode !== Train.Automatic
 
                     Layout.alignment: Qt.AlignHCenter
                     Layout.preferredHeight: 80
@@ -72,13 +73,17 @@ Item {
                         target: root.device
                         property: "speed"
                         value: speedSlider.value
-                        when: root.device !== null
+                        when: root.device !== null && (!root.train || root.train.control_mode !== Train.Automatic)
                     }
                 }
 
                 Button {
-                    text: "Stop"
-                    onClicked: speedSlider.value = 0
+                    text: root.train && root.train.halted_by_stop ? "Resume" : "Stop"
+                    highlighted: root.train && root.train.halted_by_stop
+                    onClicked: {
+                        if (root.train)
+                            root.train.toggle_stop()
+                    }
                     Layout.fillWidth: true
                 }
 

--- a/Controller/tests/test_plan_executor.py
+++ b/Controller/tests/test_plan_executor.py
@@ -382,6 +382,7 @@ def test_pause_releases_leg_and_keeps_orders():
 
     train.set_control_mode(ControlMode.Manual)
     assert train.executor.status == ExecutorState.PAUSED
+    assert not train.halted_by_stop
     assert network.owner_of(leg.segments[0]) is None
     assert train.orders.count == 2
     assert train.current_order_index == 0

--- a/Controller/tests/test_simulator_pause.py
+++ b/Controller/tests/test_simulator_pause.py
@@ -100,3 +100,23 @@ def test_step_delay_uses_abs_speed():
     sim._sim_device.set_speed(-50)
     sim.onSpeedChanged()
     assert sim._step_delay == 40 / 50
+
+
+def test_restoring_speed_unpauses_simulation():
+    network = MagicMock()
+    trains = MagicMock()
+    sim = Simulator(network, trains)
+    sim._current_node_id = "nodeA"
+    sim._previous_node_id = None
+    sim._marker_consumed = False
+    sim._sim_device = TrainDeviceSim()
+    sim.set_is_running(True)
+    sim._sim_device.speed_changed.connect(sim.onSpeedChanged)
+
+    sim.onSpeedChanged()
+    assert sim._run_task is None
+
+    with patch("python.simulator.asyncio.ensure_future", side_effect=_close_coro) as ensure_future:
+        sim._sim_device.set_speed(30)
+
+    ensure_future.assert_called_once()

--- a/Controller/tests/test_stop_toggle.py
+++ b/Controller/tests/test_stop_toggle.py
@@ -1,0 +1,278 @@
+"""B2.1 Stop button pause/resume with previous speed."""
+
+import asyncio
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+from PySide6.QtGui import QColor
+from PySide6.QtWidgets import QApplication
+
+import python.models.project_storage as project
+import python.network_manager as net
+from python.connectorregister import ConnectorRegister
+from python.items.marker import MarkerState
+from python.items.rail import Rail, RailType
+from python.items.train import ControlMode, Train
+from python.items.train_device_sim import TrainDeviceSim
+from python.models.rails import Rails
+from python.plan_executor import ExecutorState, FALLBACK_SPEED
+from python.planner import Planner
+
+TEST_TRACK = "tests/tracks/rails.json"
+YELLOW = "#ffff00"
+RED = "#ff0000"
+
+
+@pytest.fixture(scope="session", autouse=True)
+def ensure_qapp():
+    app = QApplication.instance() or QApplication([])
+    yield app
+
+
+def _planner_from_track(path: str):
+    data = project.loadDataFromFile(Path(path))
+    rails = [Rail.load_data(d) for d in data.get("rails", [])]
+    mock_rails = MagicMock()
+    mock_rails.items.return_value = rails
+    mock_rails.findRailData.side_effect = (
+        lambda rail_id: next((r for r in rails if r.id == int(rail_id)), None)
+    )
+    network = net.NetworkManager(mock_rails)
+    network.generate()
+    return Planner(mock_rails, network), network
+
+
+def _make_switch_y_layout():
+    rails = Rails(ConnectorRegister())
+    rails._items = [
+        Rail(type=RailType.Straight, id=1, parent=rails),
+        Rail(type=RailType.SwitchLeft, id=2, parent=rails),
+        Rail(type=RailType.Straight, id=3, parent=rails),
+        Rail(type=RailType.Straight, id=4, parent=rails),
+    ]
+    approach, switch, exit_a, exit_b = rails._items
+    approach.connectTo(switch.id, 1)
+    switch.connectTo(approach.id, 0)
+    switch.connectTo(exit_a.id, 2)
+    exit_a.connectTo(switch.id, 0)
+    switch.connectTo(exit_b.id, 1)
+    exit_b.connectTo(switch.id, 0)
+    return rails, switch
+
+
+def _force_take(rail, distance, color, path_id=None):
+    marker = next(
+        m for m in rail.markers._items
+        if m.distance == distance and (path_id is None or m.path_id in (None, "", path_id))
+    )
+    marker.set_color(QColor(color))
+    marker.set_state(MarkerState.Taken)
+    return marker
+
+
+def _planner_from_switch_y_with_markers():
+    rails, switch = _make_switch_y_layout()
+    approach, _switch_rail, exit_a, exit_b = rails._items
+    _force_take(approach, 8, "#ff0000")
+    _force_take(exit_a, 8, "#00ff00")
+    _force_take(exit_b, 8, "#0000ff")
+    network = net.NetworkManager(rails)
+    network.generate()
+    return Planner(rails, network), network, switch
+
+
+def _auto_train(planner, network, name="auto"):
+    device = TrainDeviceSim(name=name)
+    train = Train(device, network, planner)
+    return train, device
+
+
+def _manual_train():
+    network = MagicMock()
+    network.find_node_by_color.return_value = None
+    device = TrainDeviceSim(name="manual")
+    return Train(device, network), device
+
+
+def test_manual_stop_restores_positive_speed():
+    train, device = _manual_train()
+    device.set_speed(40)
+    assert train.control_mode == ControlMode.Manual
+
+    train.toggle_stop()
+    assert device.speed == 0
+    assert train.halted_by_stop
+    assert train.control_mode == ControlMode.Manual
+    assert train.executor is None
+
+    train.toggle_stop()
+    assert device.speed == 40
+    assert not train.halted_by_stop
+    assert train.control_mode == ControlMode.Manual
+
+
+def test_manual_stop_restores_negative_speed():
+    train, device = _manual_train()
+    device.set_speed(-40)
+
+    train.toggle_stop()
+    assert device.speed == 0
+    assert train.halted_by_stop
+
+    train.toggle_stop()
+    assert device.speed == -40
+    assert not train.halted_by_stop
+    assert train.control_mode == ControlMode.Manual
+
+
+def test_manual_slider_clears_halted_state():
+    train, device = _manual_train()
+    device.set_speed(40)
+    train.toggle_stop()
+    assert train.halted_by_stop
+    assert device.speed == 0
+
+    device.set_speed(50)
+    assert not train.halted_by_stop
+    assert device.speed == 50
+    assert train.control_mode == ControlMode.Manual
+
+
+def test_auto_stop_pauses_and_resumes_same_order():
+    planner, network = _planner_from_track(TEST_TRACK)
+    yellow = network.find_node_by_color(YELLOW)
+    red = network.find_node_by_color(RED)
+    leg = planner.compute_leg(yellow, red)
+
+    train, device = _auto_train(planner, network)
+    device.set_speed(40)
+    train.set_current_node_id(yellow)
+    train.add_order(red, 0.0)
+    train.add_order(yellow, 0.0)
+    train.set_control_mode(ControlMode.Automatic)
+    assert train.executor.status == ExecutorState.MOVING
+    assert train.current_order_index == 0
+    assert network.owner_of(leg.segments[0]) == device.name
+
+    train.toggle_stop()
+    assert train.control_mode == ControlMode.Automatic
+    assert train.halted_by_stop
+    assert train.executor.status == ExecutorState.PAUSED
+    assert device.speed == 0
+    assert train.orders.count == 2
+    assert train.current_order_index == 0
+    assert network.owner_of(leg.segments[0]) is None
+
+    train.toggle_stop()
+    assert train.control_mode == ControlMode.Automatic
+    assert not train.halted_by_stop
+    assert train.executor.status == ExecutorState.MOVING
+    assert abs(device.speed) == 40
+    assert train.current_order_index == 0
+    assert train.orders.count == 2
+    assert network.owner_of(leg.segments[0]) == device.name
+
+
+def test_auto_stop_resume_uses_fallback_cruise_when_none():
+    planner, network = _planner_from_track(TEST_TRACK)
+    yellow = network.find_node_by_color(YELLOW)
+    red = network.find_node_by_color(RED)
+
+    train, device = _auto_train(planner, network)
+    train.set_current_node_id(yellow)
+    train.add_order(red, 0.0)
+    train.set_control_mode(ControlMode.Automatic)
+    assert abs(device.speed) == FALLBACK_SPEED
+
+    train.toggle_stop()
+    assert device.speed == 0
+    assert train.control_mode == ControlMode.Automatic
+
+    train.toggle_stop()
+    assert abs(device.speed) == FALLBACK_SPEED
+    assert train.executor.status == ExecutorState.MOVING
+
+
+def test_auto_stop_during_wait_resumes_toward_next_order():
+    planner, network, _switch = _planner_from_switch_y_with_markers()
+    start = network.find_node_by_color("#ff0000")
+    dest = network.find_node_by_color("#00ff00")
+    assert start and dest
+
+    train, device = _auto_train(planner, network)
+    device.set_speed(40)
+    train.set_current_node_id(start)
+    train.add_order(dest, 5.0)
+    train.add_order(start, 0.0)
+    train.set_control_mode(ControlMode.Automatic)
+    assert train.executor.status == ExecutorState.MOVING
+    assert train.current_order_index == 0
+
+    async def scenario():
+        device.set_color(QColor("#00ff00"))
+        assert train.current_node_id == dest
+        assert train.executor.status == ExecutorState.WAITING
+        assert train.current_order_index == 0
+
+        train.toggle_stop()
+        assert train.control_mode == ControlMode.Automatic
+        assert train.halted_by_stop
+        assert train.executor.status == ExecutorState.PAUSED
+        assert device.speed == 0
+        assert train.current_order_index == 0
+        assert train.orders.count == 2
+
+        train.toggle_stop()
+        assert train.control_mode == ControlMode.Automatic
+        assert not train.halted_by_stop
+        assert train.current_order_index == 1
+        assert train.executor.status == ExecutorState.MOVING
+        assert abs(device.speed) == 40
+        assert train.orders.count == 2
+
+    asyncio.run(scenario())
+
+
+def test_auto_stop_resume_stays_waiting_for_localization():
+    planner, network = _planner_from_track(TEST_TRACK)
+    red = network.find_node_by_color(RED)
+
+    train, device = _auto_train(planner, network)
+    train.add_order(red, 0.0)
+    train.set_control_mode(ControlMode.Automatic)
+    assert train.executor.status == ExecutorState.WAITING_FOR_LOCALIZATION
+    assert device.speed == 0
+
+    train.toggle_stop()
+    assert train.halted_by_stop
+    assert train.control_mode == ControlMode.Automatic
+    assert train.executor.status == ExecutorState.PAUSED
+    assert device.speed == 0
+
+    train.toggle_stop()
+    assert not train.halted_by_stop
+    assert train.control_mode == ControlMode.Automatic
+    assert train.executor.status == ExecutorState.WAITING_FOR_LOCALIZATION
+    assert device.speed == 0
+
+
+def test_mode_switch_does_not_set_halted_by_stop():
+    planner, network = _planner_from_track(TEST_TRACK)
+    yellow = network.find_node_by_color(YELLOW)
+    red = network.find_node_by_color(RED)
+    leg = planner.compute_leg(yellow, red)
+
+    train, device = _auto_train(planner, network)
+    train.set_current_node_id(yellow)
+    train.add_order(red, 0.0)
+    train.add_order(yellow, 0.0)
+    train.set_control_mode(ControlMode.Automatic)
+    assert train.executor.status == ExecutorState.MOVING
+
+    train.set_control_mode(ControlMode.Manual)
+    assert train.executor.status == ExecutorState.PAUSED
+    assert not train.halted_by_stop
+    assert network.owner_of(leg.segments[0]) is None
+    assert train.orders.count == 2
+    assert train.current_order_index == 0


### PR DESCRIPTION
## Summary
- Stop is a per-train halt/resume toggle: Manual restores signed speed; Automatic pauses/resumes the executor without changing control_mode
- Pausing during a stop wait treats the wait as complete and resumes toward the next order only
- Button shows Resume while halted; speed slider is ignored in Automatic

## Test plan
- [ ] Manual: Stop at +40 and -40, press again, previous signed speed returns
- [ ] Manual: Stop, then drag slider to a non-zero speed — halt clears and the train moves
- [ ] Automatic: Stop while moving — speed 0, mode stays Auto, same next order; Resume continues at previous cruise
- [ ] Automatic: Stop during a wait — Resume leaves toward the next order only
- [ ] Simulator: Stop then Resume, fake train keeps emitting colors
- [ ] pytest: `tests/test_stop_toggle.py`, `tests/test_plan_executor.py`, `tests/test_simulator_pause.py`

Closes #185