### PR TITLE
C2.2: lock switches on reserved legs

### DIFF
--- a/Controller/TrainsController.pyproject
+++ b/Controller/TrainsController.pyproject
@@ -15,6 +15,7 @@
         "tests/test_plan_executor.py",
         "tests/test_stop_toggle.py",
         "tests/test_switch_position.py",
+        "tests/test_switch_lock.py",
         "tests/test_switch_device.py",
         "tests/test_switch_device_hw.py",
         "tests/test_hub_role.py",

--- a/Controller/src/python/items/rail.py
+++ b/Controller/src/python/items/rail.py
@@ -33,10 +33,17 @@ RailSource = {
 SWITCH_PATH_IDS = ("A", "B")
 DEFAULT_SWITCH_POSITION = "A"
 
+
+class ControlMode(IntEnum):
+    Manual = 1
+    Automatic = 2
+
+
 @QmlElement
 class Rail(QObject):
     last_id = 0  # static variable
     QEnum(RailType)
+    QEnum(ControlMode)
 
     def generate_id(id):   # static method
         if id == 0:
@@ -93,8 +100,10 @@ class Rail(QObject):
         self._path_indicators = PathIndicators(parent=self)
         self._reservation_indicators = PathIndicators(parent=self)
         self._reserved = False  # reserved by train
-        # Session-only logical turnout position; TODO sync from switch hub on BLE connect (Auto/Manual = C2)
+        # Session-only logical turnout; mode/lock are not persisted (C2.2)
         self._switch_position = DEFAULT_SWITCH_POSITION
+        self._control_mode = ControlMode.Manual
+        self._locked_by = ""
 
         self._paths = {}                            # dictionary
 
@@ -267,6 +276,56 @@ class Rail(QObject):
     switch_position_changed = Signal()
     switch_position = Property(str, switch_position, set_switch_position, notify=switch_position_changed)
 
+    def control_mode(self):
+        return self._control_mode
+
+    def set_control_mode(self, value):
+        if not self.is_switch():
+            return
+        value = ControlMode(int(value))
+        if self._control_mode == value:
+            return
+        self._control_mode = value
+        self.control_mode_changed.emit()
+
+    control_mode_changed = Signal()
+    control_mode = Property(int, control_mode, set_control_mode, notify=control_mode_changed)
+
+    def locked(self):
+        return bool(self._locked_by)
+
+    locked_changed = Signal()
+    locked = Property(bool, locked, notify=locked_changed)
+
+    def locked_by(self):
+        return self._locked_by
+
+    locked_by_changed = Signal()
+    locked_by = Property(str, locked_by, notify=locked_by_changed)
+
+    def lock_for(self, owner):
+        if not self.is_switch() or not owner:
+            return
+        if self._locked_by == owner:
+            return
+        self._locked_by = owner
+        self.locked_changed.emit()
+        self.locked_by_changed.emit()
+
+    def unlock_for(self, owner):
+        if not self.is_switch() or not owner:
+            return
+        if self._locked_by != owner:
+            return
+        self.unlock()
+
+    def unlock(self):
+        if not self._locked_by:
+            return
+        self._locked_by = ""
+        self.locked_changed.emit()
+        self.locked_by_changed.emit()
+
     @Slot(str)
     def setSwitchPosition(self, path_id):
         self.set_switch_position(path_id)
@@ -274,6 +333,12 @@ class Rail(QObject):
     @Slot()
     def toggleSwitchPosition(self):
         if not self.is_switch():
+            return
+        if self._locked_by:
+            print(f"Rail {self._id}: switch toggle rejected (locked by {self._locked_by})")
+            return
+        if self._control_mode != ControlMode.Manual:
+            print(f"Rail {self._id}: switch toggle rejected (Automatic mode)")
             return
         self.set_switch_position("B" if self._switch_position == "A" else "A")
 

--- a/Controller/src/python/network_manager.py
+++ b/Controller/src/python/network_manager.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 from PySide6.QtCore import QObject, Slot, Property, Signal
 from PySide6.QtGui import QColor
+from python.items.rail import Rail
 from python.network_generator import NetworkGenerator
 
 class NetworkManager(QObject):
@@ -89,14 +90,53 @@ class NetworkManager(QObject):
             return
         for segment_id in [sid for sid, o in self._owners.items() if o == owner]:
             self.release_segment(segment_id, owner)
+        self._unlock_switches_for(owner)
+
+    def _required_switches_for_segments(self, segment_ids) -> list[tuple[Rail, str]] | None:
+        """Switch rails and path_ids required by segment_data, or None on path_id conflict.
+
+        Non-Rail / non-switch entries are ignored (keeps MagicMock rails in unit tests inert).
+        """
+        ordered: dict[int, tuple[Rail, str]] = {}
+        for segment_id in segment_ids:
+            segment = self._segments.get(segment_id)
+            if segment is None:
+                continue
+            for rail_data in segment[2].get("segment_data", []):
+                rail = self._rails.findRailData(rail_data["rail_id"])
+                if not isinstance(rail, Rail) or not rail.is_switch():
+                    continue
+                path_id = rail_data["path_id"]
+                if rail.id in ordered and ordered[rail.id][1] != path_id:
+                    return None
+                if rail.id not in ordered:
+                    ordered[rail.id] = (rail, path_id)
+        return list(ordered.values())
+
+    def _unlock_switches_for(self, owner) -> None:
+        for rail in self._rails.items():
+            if isinstance(rail, Rail) and rail.is_switch():
+                rail.unlock_for(owner)
+
+    def _unlock_all_switches(self) -> None:
+        for rail in self._rails.items():
+            if isinstance(rail, Rail) and rail.is_switch():
+                rail.unlock()
+
+    def _apply_switch_locks(self, owner, required: list[tuple[Rail, str]]) -> None:
+        for rail, path_id in required:
+            rail.set_switch_position(path_id)
+            rail.lock_for(owner)
 
     def try_reserve_leg(self, owner, segment_ids) -> bool:
         """Atomically reserve every segment of a planned leg for owner.
 
         Auto executor (B1) entry point: call before departure with
         LegResult.segments. Returns True if all segments are free or already
-        owned by owner (then owns all). Returns False on conflict or unknown
-        segment id — ownership is unchanged (Hold). Empty leg succeeds.
+        owned by owner (then owns all). Sets and locks required switch rails.
+        Returns False on conflict, unknown segment, switch path conflict, or
+        a required switch locked by another owner — ownership is unchanged (Hold).
+        Empty leg succeeds.
         """
         if not owner:
             return False
@@ -111,6 +151,14 @@ class NetworkManager(QObject):
             if current is not None and current != owner:
                 return False
 
+        required = self._required_switches_for_segments(ids)
+        if required is None:
+            return False
+        for rail, _path_id in required:
+            locked_by = rail.locked_by
+            if locked_by and locked_by != owner:
+                return False
+
         newly_taken = []
         for segment_id in ids:
             if self._owners.get(segment_id) == owner:
@@ -120,6 +168,8 @@ class NetworkManager(QObject):
                     self.release_segment(taken, owner)
                 return False
             newly_taken.append(segment_id)
+
+        self._apply_switch_locks(owner, required)
         return True
 
     def release_leg(self, owner, segment_ids) -> bool:
@@ -127,8 +177,8 @@ class NetworkManager(QObject):
 
         Free segments are skipped. Segments owned by another party are left
         alone and cause False, but this owner's segments in the list are still
-        released (best-effort). Empty list succeeds. Use release_all_for for
-        pause/manual full cleanup.
+        released (best-effort). Unlocks switches locked by this owner. Empty
+        list succeeds. Use release_all_for for pause/manual full cleanup.
         """
         if not owner:
             return False
@@ -143,6 +193,7 @@ class NetworkManager(QObject):
                 continue
             if not self.release_segment(segment_id, owner):
                 ok = False
+        self._unlock_switches_for(owner)
         return ok
 
     def reserve_segments(self, segment_ids) -> bool:
@@ -419,6 +470,7 @@ class NetworkManager(QObject):
     def generate(self):
         self._segments = {}
         self._owners = {}
+        self._unlock_all_switches()
         self._graph, self._nodeMarkerMap = self._generator.generate(self._rails.items(), True)
 
         edges = self._graph.edges(data=True)

--- a/Controller/src/qml/DevicesPanel.qml
+++ b/Controller/src/qml/DevicesPanel.qml
@@ -159,7 +159,7 @@ Item {
                             required property int index
 
                             width: switchRails.width
-                            height: object && object.is_switch() ? 40 : 0
+                            height: object && object.is_switch() ? 48 : 0
                             visible: height > 0
                             color: root.selectedRailIndex === index ? "#cce5ff" : "transparent"
 
@@ -177,18 +177,29 @@ Item {
                                         return "Rail " + object.id
                                               + " (" + (object.type === 2 ? "SwitchLeft" : "SwitchRight") + ")"
                                               + "  pos " + object.switch_position
+                                              + (object.locked ? "  locked" : "")
                                               + "  —  " + switchDevices.deviceNameForRail(object)
                                     }
                                     Layout.fillWidth: true
-                                }
-                            }
 
-                            MouseArea {
-                                anchors.fill: parent
-                                enabled: railRow.visible
-                                onClicked: {
-                                    root.selectedRailIndex = index
-                                    root.selectedRail = object
+                                    MouseArea {
+                                        anchors.fill: parent
+                                        onClicked: {
+                                            root.selectedRailIndex = railRow.index
+                                            root.selectedRail = railRow.object
+                                        }
+                                    }
+                                }
+
+                                Switch {
+                                    checked: object && object.control_mode === Rail.Automatic
+                                    enabled: object && !object.locked
+                                    text: checked ? "Auto" : "Manual"
+                                    onToggled: {
+                                        if (!object)
+                                            return
+                                        object.control_mode = checked ? Rail.Automatic : Rail.Manual
+                                    }
                                 }
                             }
                         }

--- a/Controller/tests/test_switch_lock.py
+++ b/Controller/tests/test_switch_lock.py
@@ -1,0 +1,146 @@
+import pytest
+from PySide6.QtGui import QColor
+from PySide6.QtWidgets import QApplication
+
+import python.network_manager as net
+from python.connectorregister import ConnectorRegister
+from python.items.marker import MarkerState
+from python.items.rail import Rail, RailType
+from python.models.rails import Rails
+from python.planner import Planner
+
+
+@pytest.fixture(scope="session", autouse=True)
+def ensure_qapp():
+    app = QApplication.instance() or QApplication([])
+    yield app
+
+
+def _make_switch_y_layout():
+    """Straight approach into SwitchLeft with two straight exits (A and B)."""
+    rails = Rails(ConnectorRegister())
+    rails._items = [
+        Rail(type=RailType.Straight, id=1, parent=rails),
+        Rail(type=RailType.SwitchLeft, id=2, parent=rails),
+        Rail(type=RailType.Straight, id=3, parent=rails),
+        Rail(type=RailType.Straight, id=4, parent=rails),
+    ]
+    approach, switch, exit_a, exit_b = rails._items
+    approach.connectTo(switch.id, 1)
+    switch.connectTo(approach.id, 0)
+    switch.connectTo(exit_a.id, 2)
+    exit_a.connectTo(switch.id, 0)
+    switch.connectTo(exit_b.id, 1)
+    exit_b.connectTo(switch.id, 0)
+    return rails, switch
+
+
+def _force_take(rail, distance, color, path_id=None):
+    marker = next(
+        m for m in rail.markers._items
+        if m.distance == distance and (path_id is None or m.path_id in (None, "", path_id))
+    )
+    marker.set_color(QColor(color))
+    marker.set_state(MarkerState.Taken)
+    return marker
+
+
+def _planner_from_switch_y_with_markers():
+    rails, switch = _make_switch_y_layout()
+    approach, _switch_rail, exit_a, exit_b = rails._items
+    _force_take(approach, 8, "#ff0000")
+    _force_take(exit_a, 8, "#00ff00")
+    _force_take(exit_b, 8, "#0000ff")
+    network = net.NetworkManager(rails)
+    network.generate()
+    return Planner(rails, network), network, switch
+
+
+def test_reserve_leg_sets_path_b_and_blocks_toggle():
+    planner, network, switch = _planner_from_switch_y_with_markers()
+    approach = network.find_node_by_color("#ff0000")
+    exit_b = network.find_node_by_color("#0000ff")
+    leg = planner.compute_leg(approach, exit_b)
+    assert leg is not None
+
+    assert network.try_reserve_leg("train-a", leg.segments)
+    assert switch.switch_position == "B"
+    assert switch.path_indicators.path_id_active == "B"
+    assert switch.locked
+    assert switch.locked_by == "train-a"
+
+    switch.toggleSwitchPosition()
+    assert switch.switch_position == "B"
+
+
+def test_release_leg_unlocks_and_manual_toggle_works():
+    planner, network, switch = _planner_from_switch_y_with_markers()
+    approach = network.find_node_by_color("#ff0000")
+    exit_b = network.find_node_by_color("#0000ff")
+    leg = planner.compute_leg(approach, exit_b)
+    assert leg is not None
+
+    assert network.try_reserve_leg("train-a", leg.segments)
+    assert network.release_leg("train-a", leg.segments)
+    assert not switch.locked
+    assert switch.locked_by == ""
+
+    switch.toggleSwitchPosition()
+    assert switch.switch_position == "A"
+
+
+def test_foreign_switch_lock_fails_atomically():
+    planner, network, switch = _planner_from_switch_y_with_markers()
+    approach = network.find_node_by_color("#ff0000")
+    exit_a = network.find_node_by_color("#00ff00")
+    leg = planner.compute_leg(approach, exit_a)
+    assert leg is not None
+
+    switch.set_switch_position("B")
+    switch.lock_for("train-a")
+
+    assert not network.try_reserve_leg("train-b", leg.segments)
+    assert all(network.owner_of(sid) is None for sid in leg.segments)
+    assert switch.switch_position == "B"
+    assert switch.locked_by == "train-a"
+
+
+def test_same_owner_rereserve_keeps_lock():
+    planner, network, switch = _planner_from_switch_y_with_markers()
+    approach = network.find_node_by_color("#ff0000")
+    exit_b = network.find_node_by_color("#0000ff")
+    leg = planner.compute_leg(approach, exit_b)
+    assert leg is not None
+
+    assert network.try_reserve_leg("train-a", leg.segments)
+    assert network.try_reserve_leg("train-a", leg.segments)
+    assert switch.switch_position == "B"
+    assert switch.locked_by == "train-a"
+
+
+def test_release_all_for_unlocks_owner_switches():
+    planner, network, switch = _planner_from_switch_y_with_markers()
+    approach = network.find_node_by_color("#ff0000")
+    exit_b = network.find_node_by_color("#0000ff")
+    leg = planner.compute_leg(approach, exit_b)
+    assert leg is not None
+
+    assert network.try_reserve_leg("train-a", leg.segments)
+    network.release_all_for("train-a")
+    assert not switch.locked
+    assert all(network.owner_of(sid) is None for sid in leg.segments)
+
+
+def test_generate_clears_switch_locks():
+    planner, network, switch = _planner_from_switch_y_with_markers()
+    approach = network.find_node_by_color("#ff0000")
+    exit_b = network.find_node_by_color("#0000ff")
+    leg = planner.compute_leg(approach, exit_b)
+    assert leg is not None
+
+    assert network.try_reserve_leg("train-a", leg.segments)
+    assert switch.locked
+
+    network.generate()
+    assert not switch.locked
+    assert switch.locked_by == ""

--- a/Controller/tests/test_switch_position.py
+++ b/Controller/tests/test_switch_position.py
@@ -1,7 +1,7 @@
 import pytest
 from PySide6.QtWidgets import QApplication
 
-from python.items.rail import Rail, RailType
+from python.items.rail import ControlMode, Rail, RailType
 
 
 @pytest.fixture(scope="session", autouse=True)
@@ -57,3 +57,56 @@ def test_switch_ignores_invalid_path_id():
 
     assert switch.switch_position == "A"
     assert switch.path_indicators.path_id_active == "A"
+
+
+def test_switch_default_mode_manual_unlocked():
+    switch = Rail(type=RailType.SwitchLeft, id=6)
+
+    assert switch.control_mode == ControlMode.Manual
+    assert not switch.locked
+    assert switch.locked_by == ""
+
+
+def test_switch_toggle_rejected_in_automatic():
+    switch = Rail(type=RailType.SwitchLeft, id=7)
+    switch.set_control_mode(ControlMode.Automatic)
+
+    switch.toggleSwitchPosition()
+
+    assert switch.switch_position == "A"
+    assert switch.path_indicators.path_id_active == "A"
+
+
+def test_switch_toggle_rejected_when_locked():
+    switch = Rail(type=RailType.SwitchLeft, id=8)
+    switch.lock_for("train-a")
+
+    switch.toggleSwitchPosition()
+
+    assert switch.switch_position == "A"
+    assert switch.locked
+    assert switch.locked_by == "train-a"
+
+
+def test_switch_set_position_works_while_locked():
+    switch = Rail(type=RailType.SwitchLeft, id=9)
+    switch.lock_for("train-a")
+
+    switch.set_switch_position("B")
+
+    assert switch.switch_position == "B"
+    assert switch.path_indicators.path_id_active == "B"
+    assert switch.locked
+
+
+def test_switch_unlock_for_only_matching_owner():
+    switch = Rail(type=RailType.SwitchLeft, id=10)
+    switch.lock_for("train-a")
+
+    switch.unlock_for("train-b")
+    assert switch.locked
+    assert switch.locked_by == "train-a"
+
+    switch.unlock_for("train-a")
+    assert not switch.locked
+    assert switch.locked_by == ""


### PR DESCRIPTION
## Summary
- Add per-switch Manual/Automatic mode and owner lock on switch rails.
- `try_reserve_leg` sets required turnout positions and locks them; click-toggle is rejected while locked or in Automatic.
- Release (`release_leg` / `release_all_for` / `generate`) unlocks; DevicesPanel shows locked state and a Manual/Auto control.

Closes #143

## Test plan
- [ ] Run mode: reserve a leg that needs path B — switch indicators show B and canvas click cannot flip until release
- [ ] After release, Manual click toggles A/B again
- [ ] DevicesPanel: Auto mode rejects canvas toggle even when unlocked; Manual toggle disabled while locked
- [ ] `pytest` from `Controller/` (includes `tests/test_switch_lock.py` and `tests/test_switch_position.py`)