### PR TITLE
[SW2.1] fix(executor): wait for switch ack before Auto departs

### DIFF
--- a/Controller/src/python/app_context.py
+++ b/Controller/src/python/app_context.py
@@ -28,7 +28,7 @@ class AppContext:
         self.railTypes = RailTypes()
         self.network = NetworkManager(self.projectStorage.currentProject.rails)
         self.planner = Planner(self.projectStorage.currentProject.rails, self.network)
-        self.trains = Trains(self.network, self.trainDevices, self.planner)
+        self.trains = Trains(self.network, self.trainDevices, self.planner, switch_devices=self.switchDevices)
         self.simulator = Simulator(self.network, self.trains)
         self.projectStorage.set_trains(self.trains)
 

--- a/Controller/src/python/items/switch_device.py
+++ b/Controller/src/python/items/switch_device.py
@@ -1,6 +1,8 @@
 # This Python file uses the following encoding: utf-8
 from __future__ import annotations
 
+import asyncio
+
 from PySide6.QtCore import QObject, Property, Signal, Slot
 
 from python.items.rail import SWITCH_PATH_IDS, DEFAULT_SWITCH_POSITION
@@ -20,6 +22,8 @@ class SwitchDevice(QObject):
         self._name = name
         self._initialized = initialized
         self._position = DEFAULT_SWITCH_POSITION
+        self._confirmed_position = DEFAULT_SWITCH_POSITION
+        self._confirm_waiters: list[tuple[str, asyncio.Event]] = []
         self._bound_rail = None
 
     def role(self):
@@ -58,6 +62,7 @@ class SwitchDevice(QObject):
         if self._position == value:
             return
         self._position = value
+        self._confirmed_position = None
         self._apply_position(value)
         self.position_changed.emit()
 
@@ -66,6 +71,32 @@ class SwitchDevice(QObject):
         pass
 
     position = Property(str, position, set_position, notify=position_changed)
+
+    def is_confirmed(self, path_id: str) -> bool:
+        return self._confirmed_position == path_id
+
+    def _confirm_position(self, path_id: str):
+        if path_id not in SWITCH_PATH_IDS or path_id != self._position:
+            return
+        self._confirmed_position = path_id
+        remaining = []
+        for wanted, event in self._confirm_waiters:
+            if wanted == path_id:
+                event.set()
+            else:
+                remaining.append((wanted, event))
+        self._confirm_waiters = remaining
+
+    async def wait_until_confirmed(self, path_id: str) -> bool:
+        if self.is_confirmed(path_id):
+            return True
+        event = asyncio.Event()
+        self._confirm_waiters.append((path_id, event))
+        if self.is_confirmed(path_id):
+            self._confirm_waiters = [(wanted, waiter) for wanted, waiter in self._confirm_waiters if waiter is not event]
+            return True
+        await event.wait()
+        return self.is_confirmed(path_id)
 
     @Slot(str)
     def setPosition(self, path_id):

--- a/Controller/src/python/items/switch_device_hw.py
+++ b/Controller/src/python/items/switch_device_hw.py
@@ -44,6 +44,10 @@ class SwitchDeviceHW(SwitchDevice):
         if rail is not None:
             rail.set_switch_position(value)
 
+    def _on_position_ack(self, ack: str):
+        print(f"SwitchDeviceHW {self._name}: position ack {ack}")
+        self._confirm_position(ack)
+
     async def _async_voltage_status(self):
         await self._ble.ready_event.wait()
         self.send("vol")
@@ -63,7 +67,7 @@ class SwitchDeviceHW(SwitchDevice):
                 print(f"SwitchDeviceHW {self._name}: voltage {self._voltage}")
             elif payload == b"pos":
                 ack = data[4:5].decode("utf-8", errors="replace")
-                print(f"SwitchDeviceHW {self._name}: position ack {ack}")
+                self._on_position_ack(ack)
             elif payload == b"int":
                 self.set_initialized(True)
             elif payload == b"rol":

--- a/Controller/src/python/items/switch_device_sim.py
+++ b/Controller/src/python/items/switch_device_sim.py
@@ -24,6 +24,6 @@ class SwitchDeviceSim(SwitchDevice):
 
     def _apply_position(self, value):
         rail = self._bound_rail
-        if rail is None:
-            return
-        rail.set_switch_position(value)
+        if rail is not None:
+            rail.set_switch_position(value)
+        self._confirm_position(value)

--- a/Controller/src/python/items/train.py
+++ b/Controller/src/python/items/train.py
@@ -28,7 +28,7 @@ class ControlMode(IntEnum):
 class Train(QObject):
     QEnum(ControlMode)
 
-    def __init__(self, device, network, planner=None, parent=None):
+    def __init__(self, device, network, planner=None, parent=None, switch_devices=None):
         super().__init__(parent)
         self._device = device
         self._network = network
@@ -44,7 +44,7 @@ class Train(QObject):
         self._allow_reverse = False
         self._halted_by_stop = False
         self._resume_speed = 0
-        self._executor = PlanExecutor(self, planner, network, parent=self) if planner is not None else None
+        self._executor = PlanExecutor(self, planner, network, parent=self, switch_devices=switch_devices) if planner is not None else None
 
         device.color_changed.connect(self.on_color_changed)
         device.speed_changed.connect(self._on_speed_changed)

--- a/Controller/src/python/models/switch_devices.py
+++ b/Controller/src/python/models/switch_devices.py
@@ -148,3 +148,23 @@ class SwitchDevices(ObjectBasedModel[SwitchDevice]):
         if self._rails is None:
             return []
         return [r for r in self._rails.items() if r.is_switch()]
+
+    def unconfirmed_hardware(self, required: list[tuple[Rail, str]]) -> list[tuple[SwitchDevice, str]]:
+        """Bound hardware devices that still need a pos ack for the required path."""
+        pending = []
+        for rail, path_id in required or []:
+            device = self._rail_to_device.get(getattr(rail, "id", None))
+            if device is None or device.is_simulated():
+                continue
+            if device.is_confirmed(path_id):
+                continue
+            pending.append((device, path_id))
+        return pending
+
+    def command_required(self, required: list[tuple[Rail, str]]) -> None:
+        """Send set_position to each bound device for the reserved switch path."""
+        for rail, path_id in required or []:
+            device = self._rail_to_device.get(getattr(rail, "id", None))
+            if device is None:
+                continue
+            device.set_position(path_id)

--- a/Controller/src/python/models/trains.py
+++ b/Controller/src/python/models/trains.py
@@ -11,10 +11,11 @@ class Trains(ObjectBasedModel[Train]):
 
     _item_class = Train
 
-    def __init__(self, network, train_devices, planner=None, parent=None):
+    def __init__(self, network, train_devices, planner=None, parent=None, switch_devices=None):
         super().__init__(parent)
         self._network = network
         self._planner = planner
+        self._switch_devices = switch_devices
         self._project = None
         self._last_order_hint = ""
         train_devices.device_connected.connect(self.add_train)
@@ -26,7 +27,7 @@ class Trains(ObjectBasedModel[Train]):
             self._apply_stored_plan(train)
 
     def add_train(self, device):
-        train = Train(device=device, network=self._network, planner=self._planner, parent=self)
+        train = Train(device=device, network=self._network, planner=self._planner, parent=self, switch_devices=self._switch_devices)
         device.disconnected.connect(lambda d: self.remove_by_device(d))
         self.append(train)
         self._apply_stored_plan(train)

--- a/Controller/src/python/network_manager.py
+++ b/Controller/src/python/network_manager.py
@@ -113,6 +113,11 @@ class NetworkManager(QObject):
                     ordered[rail.id] = (rail, path_id)
         return list(ordered.values())
 
+    def required_switches_for_segments(self, segment_ids) -> list[tuple[Rail, str]]:
+        """Switch rails required by the leg, or empty if none / path conflict."""
+        required = self._required_switches_for_segments(segment_ids)
+        return required if required else []
+
     def _unlock_switches_for(self, owner) -> None:
         for rail in self._rails.items():
             if isinstance(rail, Rail) and rail.is_switch():

--- a/Controller/src/python/plan_executor.py
+++ b/Controller/src/python/plan_executor.py
@@ -11,6 +11,7 @@ QML_IMPORT_MAJOR_VERSION = 1
 
 FALLBACK_SPEED = 40
 MIN_AUTO_SPEED = 30
+SWITCH_CONFIRM_TIMEOUT_S = 2.0
 
 
 class ExecutorState:
@@ -20,18 +21,21 @@ class ExecutorState:
     MOVING = "Moving"
     WAITING = "Waiting"
     PAUSED = "Paused"
+    SETTING_SWITCHES = "Setting switches"
 
 
 @QmlElement
 class PlanExecutor(QObject):
     """Loops a train's orders with whole-leg reservation and Hold on conflict."""
 
-    def __init__(self, train, planner, network, parent=None, hold_retry_s=0.5):
+    def __init__(self, train, planner, network, parent=None, hold_retry_s=0.5, switch_devices=None, switch_confirm_timeout_s=SWITCH_CONFIRM_TIMEOUT_S):
         super().__init__(parent)
         self._train = train
         self._planner = planner
         self._network = network
+        self._switch_devices = switch_devices
         self._hold_retry_s = float(hold_retry_s)
+        self._switch_confirm_timeout_s = float(switch_confirm_timeout_s)
         self._state = ExecutorState.PAUSED
         self._hold_reason = ""
         self._previous_node_id = ""
@@ -134,6 +138,30 @@ class PlanExecutor(QObject):
         except asyncio.CancelledError:
             return
 
+    def _pending_switch_confirms(self, required):
+        if self._switch_devices is None:
+            return []
+        self._switch_devices.command_required(required)
+        return self._switch_devices.unconfirmed_hardware(required)
+
+    def _begin_moving(self, flip):
+        self._apply_moving_speed(flip=flip)
+        self._set_state(ExecutorState.MOVING)
+
+    async def _wait_switches_then_move(self, pending, flip):
+        try:
+            awaits = [device.wait_until_confirmed(path_id) for device, path_id in pending]
+            await asyncio.wait_for(asyncio.gather(*awaits), timeout=self._switch_confirm_timeout_s)
+            if self._state != ExecutorState.SETTING_SWITCHES:
+                return
+            self._begin_moving(flip)
+        except asyncio.TimeoutError:
+            if self._state != ExecutorState.SETTING_SWITCHES:
+                return
+            self._hold("switch")
+        except asyncio.CancelledError:
+            return
+
     def _release_current_leg(self):
         if self._current_leg is not None:
             self._network.release_leg(self._owner(), self._current_leg.segments)
@@ -173,7 +201,7 @@ class PlanExecutor(QObject):
 
     @Slot()
     def try_depart(self):
-        if self._state == ExecutorState.PAUSED:
+        if self._state in (ExecutorState.PAUSED, ExecutorState.SETTING_SWITCHES):
             return
         if self._planner is None or self._network is None:
             return
@@ -226,9 +254,18 @@ class PlanExecutor(QObject):
         self._current_leg = leg
         self._cancel_task()
         flip = reversing or (bool(previous) and self._network.is_dead_end(current))
-        self._apply_moving_speed(flip=flip)
         self._train.set_current_segment_ids(leg.segments, f"{leg.nodes[0]}:{leg.nodes[-1]}")
-        self._set_state(ExecutorState.MOVING)
+        self._set_speed(0)
+        required = self._network.required_switches_for_segments(leg.segments)
+        pending = self._pending_switch_confirms(required)
+        if not pending:
+            self._begin_moving(flip)
+            return
+        if self._running_loop() is None:
+            self._hold("switch")
+            return
+        self._set_state(ExecutorState.SETTING_SWITCHES)
+        self._task = asyncio.ensure_future(self._wait_switches_then_move(pending, flip))
 
     def on_marker(self, node_id):
         if not node_id:

--- a/Controller/tests/test_plan_executor.py
+++ b/Controller/tests/test_plan_executor.py
@@ -19,7 +19,9 @@ from python.items.marker import MarkerState
 from python.items.rail import Rail, RailType
 from python.items.train import ControlMode, Train
 from python.items.train_device_sim import TrainDeviceSim
+from python.items.switch_device_hw import SwitchDeviceHW
 from python.models.rails import Rails
+from python.models.switch_devices import SwitchDevices
 from python.plan_executor import ExecutorState, FALLBACK_SPEED, MIN_AUTO_SPEED
 from python.planner import LegResult, Planner
 
@@ -86,9 +88,9 @@ def _planner_from_switch_y_with_markers():
     return Planner(rails, network), network, switch
 
 
-def _auto_train(planner, network, name="auto"):
+def _auto_train(planner, network, name="auto", switch_devices=None):
     device = TrainDeviceSim(name=name)
-    train = Train(device, network, planner)
+    train = Train(device, network, planner, switch_devices=switch_devices)
     return train, device
 
 
@@ -496,3 +498,114 @@ def test_is_reverse_depart_helper():
     y_leg = y_planner.compute_leg(approach, exit_a)
     assert y_network.is_dead_end(approach)
     assert not y_network.is_reverse_depart(approach, "1-2", y_leg.nodes[1])
+
+
+class _FakeBle:
+    def __init__(self):
+        self.sent = []
+        self.client = object()
+
+    def send(self, cmd, data=b"", response=True):
+        self.sent.append((cmd, data, response))
+
+
+def _bind_hw_switch(switch_rail):
+    devices = SwitchDevices()
+    hw = SwitchDeviceHW(client=object(), hub_name="sw", ble=_FakeBle())
+    devices.append(hw)
+    devices.assignToRail(switch_rail, hw)
+    return devices, hw
+
+
+async def _until_status(train, status):
+    while train.executor.status != status:
+        await asyncio.sleep(0)
+
+
+def test_sim_switch_departs_immediately():
+    planner, network, switch = _planner_from_switch_y_with_markers()
+    start = network.find_node_by_color("#ff0000")
+    dest = network.find_node_by_color("#0000ff")
+    devices = SwitchDevices()
+    devices.assignToRail(switch, devices.addSimulated())
+
+    train, device = _auto_train(planner, network, switch_devices=devices)
+    train.set_current_node_id(start)
+    train.add_order(dest, 0.0)
+    train.set_control_mode(ControlMode.Automatic)
+
+    assert train.executor.status == ExecutorState.MOVING
+    assert device.speed > 0
+    assert switch.switch_position == "B"
+
+
+def test_hw_switch_waits_for_pos_ack_before_moving():
+    planner, network, switch = _planner_from_switch_y_with_markers()
+    start = network.find_node_by_color("#ff0000")
+    dest = network.find_node_by_color("#0000ff")
+    switch_devices, hw = _bind_hw_switch(switch)
+
+    train, device = _auto_train(planner, network, switch_devices=switch_devices)
+    train.set_current_node_id(start)
+    train.add_order(dest, 0.0)
+
+    async def scenario():
+        train.set_control_mode(ControlMode.Automatic)
+        assert train.executor.status == ExecutorState.SETTING_SWITCHES
+        assert device.speed == 0
+        assert switch.switch_position == "B"
+        assert hw.position == "B"
+        assert not hw.is_confirmed("B")
+        await asyncio.sleep(0)
+        hw._on_position_ack("B")
+        await asyncio.wait_for(_until_status(train, ExecutorState.MOVING), timeout=1)
+        assert device.speed > 0
+
+    asyncio.run(scenario())
+
+
+def test_hw_switch_timeout_holds():
+    planner, network, switch = _planner_from_switch_y_with_markers()
+    start = network.find_node_by_color("#ff0000")
+    dest = network.find_node_by_color("#0000ff")
+    switch_devices, _hw = _bind_hw_switch(switch)
+
+    train, device = _auto_train(planner, network, switch_devices=switch_devices)
+    train.executor._hold_retry_s = 10.0
+    train.executor._switch_confirm_timeout_s = 0.05
+    train.set_current_node_id(start)
+    train.add_order(dest, 0.0)
+
+    async def scenario():
+        train.set_control_mode(ControlMode.Automatic)
+        assert train.executor.status == ExecutorState.SETTING_SWITCHES
+        assert device.speed == 0
+        await asyncio.sleep(0.12)
+        assert train.executor.status == "Hold: switch"
+        assert device.speed == 0
+
+    asyncio.run(scenario())
+
+
+def test_localization_crawl_stops_while_waiting_for_switch():
+    planner, network, switch = _planner_from_switch_y_with_markers()
+    start = network.find_node_by_color("#ff0000")
+    dest = network.find_node_by_color("#0000ff")
+    switch_devices, hw = _bind_hw_switch(switch)
+
+    train, device = _auto_train(planner, network, switch_devices=switch_devices)
+    train.add_order(dest, 0.0)
+
+    async def scenario():
+        train.set_control_mode(ControlMode.Automatic)
+        assert train.executor.status == ExecutorState.WAITING_FOR_LOCALIZATION
+        assert device.speed != 0
+        train.executor.on_marker(start)
+        assert device.speed == 0
+        assert train.executor.status == ExecutorState.SETTING_SWITCHES
+        await asyncio.sleep(0)
+        hw._on_position_ack("B")
+        await asyncio.wait_for(_until_status(train, ExecutorState.MOVING), timeout=1)
+        assert device.speed > 0
+
+    asyncio.run(scenario())

--- a/Controller/tests/test_switch_device.py
+++ b/Controller/tests/test_switch_device.py
@@ -2,6 +2,7 @@ import pytest
 from PySide6.QtWidgets import QApplication
 
 from python.items.rail import Rail, RailType
+from python.items.switch_device_hw import SwitchDeviceHW
 from python.items.switch_device_sim import SwitchDeviceSim
 from python.models.switch_devices import SwitchDevices
 
@@ -30,6 +31,7 @@ def test_set_position_updates_rail():
     assert rail.switch_position == "B"
     assert rail.path_indicators.path_id_active == "B"
     assert device.position == "B"
+    assert device.is_confirmed("B")
 
 
 def test_rail_toggle_syncs_device_position():
@@ -78,3 +80,29 @@ def test_switch_rails_helper_excludes_non_switches():
     only_switches = devices.switchRails()
     assert switch in only_switches
     assert straight not in only_switches
+
+
+def test_unconfirmed_hardware_skips_sim_and_lists_pending_hubs():
+    sim_rail = Rail(type=RailType.SwitchLeft, id=1)
+    hw_rail = Rail(type=RailType.SwitchRight, id=2)
+    devices = SwitchDevices()
+    sim = devices.addSimulated()
+    devices.assignToRail(sim_rail, sim)
+
+    class _FakeBle:
+        def __init__(self):
+            self.client = object()
+
+        def send(self, cmd, data=b"", response=True):
+            pass
+
+    hw = SwitchDeviceHW(client=object(), hub_name="sw", ble=_FakeBle())
+    devices.append(hw)
+    devices.assignToRail(hw_rail, hw)
+    hw.set_position("B")
+
+    pending = devices.unconfirmed_hardware([(sim_rail, "B"), (hw_rail, "B")])
+    assert pending == [(hw, "B")]
+
+    hw._on_position_ack("B")
+    assert devices.unconfirmed_hardware([(sim_rail, "B"), (hw_rail, "B")]) == []

--- a/Controller/tests/test_switch_device_hw.py
+++ b/Controller/tests/test_switch_device_hw.py
@@ -1,3 +1,5 @@
+import asyncio
+
 import pytest
 from PySide6.QtWidgets import QApplication
 
@@ -36,6 +38,10 @@ def test_switch_device_hw_set_position_sends_pos_and_updates_rail():
     assert ("pos", b"B", True) in ble.sent
     assert rail.switch_position == "B"
     assert device.position == "B"
+    assert not device.is_confirmed("B")
+
+    device._on_position_ack("B")
+    assert device.is_confirmed("B")
 
 
 def test_switch_device_hw_role_is_switch():
@@ -43,3 +49,17 @@ def test_switch_device_hw_role_is_switch():
     device = SwitchDeviceHW(client=ble.client, hub_name="sw", ble=ble)
     assert device.role == "switch"
     assert device.isSimulated is False
+
+
+def test_wait_until_confirmed_resolves_on_pos_ack():
+    device = SwitchDeviceHW(client=object(), hub_name="sw", ble=_FakeBle())
+    device.set_position("B")
+
+    async def scenario():
+        waiter = asyncio.create_task(device.wait_until_confirmed("B"))
+        await asyncio.sleep(0)
+        assert not waiter.done()
+        device._on_position_ack("B")
+        assert await waiter is True
+
+    asyncio.run(scenario())


### PR DESCRIPTION
## Summary
- Auto reserved a leg and started the train before bound hardware switches finished throwing, so a marker next to a turnout (yellow on `rails_big` → switch 24) derailed the train.
- Hold speed at 0 in `Setting switches` until every required hub acks `pos`; timeout goes to `Hold: switch`. Sim / unbound switches stay immediate.

Closes #197

## Test plan
- [ ] Auto from yellow on the big track with a real switch hub: train stays stopped until the turnout throws, then rolls
- [ ] Leg with two hardware switches: motion starts only after both acks
- [ ] Simulated / unbound switch: no extra delay
- [ ] No ack within ~2s: `Hold: switch`, speed 0
- [ ] `pytest` in `Controller/` (wait-for-ack, sim immediate, timeout Hold, localization crawl stops)
